### PR TITLE
Ensure `Bump::new_chunk` can satisfy next request

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -84,3 +84,14 @@ fn alloc_overflow() {
     // This should panic.
     bump.alloc_layout(layout);
 }
+
+#[test]
+fn force_new_chunk_fits_well() {
+    let b = Bump::new();
+
+    // Use the first chunk for something
+    b.alloc_layout(Layout::from_size_align(1, 1).unwrap());
+
+    // Next force allocation of a new chunk with a very large request
+    b.alloc_layout(Layout::from_size_align(100_000, 1).unwrap());
+}


### PR DESCRIPTION
This commit fixes a bug that was discovered through `wasm-bindgen` in
2.2.0 (maybe introduced in #5? unsure) where a call to `Bump::new_chunk`
may not have been guaranteed to satisfy the next requested allocation,
even though it was expected to be so.

The issue was that if a large layout was allocated when space was
reserved for `ChunkFooter` the allocation request didn't take that into
account. This means that if you requested a 10kb allocation, for
example, then after allocating a 10kb chunk the chunk wouldn't have 10kb
available because the footer was used as part of that 10kb.

The fix implemented in this issue is to ensure that the size is always
increased by the size of `ChunkFooter` if necessary, guaranteeing that
the chunk returned by `Bump::new_chunk` can satisfy the next allocation
if a layout is provided.