### PR TITLE
Fix a debug assert from firing in `new_chunk`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,9 +284,10 @@ impl Bump {
             let layout: Layout =
                 layouts.map_or_else(Bump::default_chunk_layout, |(old_size, requested)| {
                     let old_doubled = old_size.checked_mul(2).unwrap();
+                    let footer_align = mem::align_of::<ChunkFooter>();
                     debug_assert_eq!(
                         old_doubled,
-                        round_up_to(old_doubled, mem::align_of::<ChunkFooter>()),
+                        round_up_to(old_doubled, footer_align),
                         "The old size was already a multiple of our chunk footer alignment, so no \
                          need to round it up again."
                     );
@@ -304,7 +305,8 @@ impl Bump {
                         size_to_allocate,
                         requested.size() + mem::size_of::<ChunkFooter>(),
                     );
-                    let align = cmp::max(mem::align_of::<ChunkFooter>(), requested.align());
+                    let size = round_up_to(size, footer_align);
+                    let align = cmp::max(footer_align, requested.align());
 
                     layout_from_size_align(size, align)
                 });

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -92,6 +92,7 @@ fn force_new_chunk_fits_well() {
     // Use the first chunk for something
     b.alloc_layout(Layout::from_size_align(1, 1).unwrap());
 
-    // Next force allocation of a new chunk with a very large request
-    b.alloc_layout(Layout::from_size_align(100_000, 1).unwrap());
+    // Next force allocation of some new chunks.
+    b.alloc_layout(Layout::from_size_align(100_001, 1).unwrap());
+    b.alloc_layout(Layout::from_size_align(100_003, 1).unwrap());
 }


### PR DESCRIPTION
A debug assert was ensuring that the previous size specified for a chunk
was aligned to the chunk footer, but the previous change in #7 didn't
actually preserve that invariant when the user-provided size was used to
allocate a new chunk. While this doesn't actually cause an issues at
runtime (I don't think) it's probably best to go ahead and fix the issue
anyway by ensuring that the user-provided size, if used, is always aligned.