### PR TITLE
Add an alloc_with function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,11 @@ name = "benches"
 path = "benches/benches.rs"
 harness = false
 
+[[bench]]
+name = "benches_alloc_with"
+path = "benches/benches_alloc_with.rs"
+harness = false
+
 [dev-dependencies]
 quickcheck = "0.8.2"
 criterion = "0.2.10"

--- a/benches/benches_alloc_with.rs
+++ b/benches/benches_alloc_with.rs
@@ -19,14 +19,14 @@ impl Default for Huge {
 fn allocate<T: Default>(n: usize) {
     let arena = bumpalo::Bump::new();
     for _ in 0..n {
-        let val: &mut T = arena.alloc(Default::default());
+        let val: &mut T = arena.alloc_with(|| Default::default());
         criterion::black_box(val);
     }
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench(
-        "allocate",
+        "allocate_with",
         ParameterizedBenchmark::new(
             "allocate-small",
             |b, n| b.iter(|| allocate::<Small>(*n)),
@@ -36,7 +36,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     );
 
     c.bench(
-        "allocate",
+        "allocate_with",
         ParameterizedBenchmark::new(
             "allocate-big",
             |b, n| b.iter(|| allocate::<Big>(*n)),
@@ -46,7 +46,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     );
 
     c.bench(
-        "allocate",
+        "allocate_with",
         ParameterizedBenchmark::new(
             "allocate-huge",
             |b, n| b.iter(|| allocate::<Huge>(*n)),

--- a/tests/alloc_with.rs
+++ b/tests/alloc_with.rs
@@ -1,0 +1,65 @@
+// All of these alloc_with tests will fail with "fatal runtime error: stack overflow" unless LLVM
+// manages to optimize the stack writes away.
+
+#[test]
+#[cfg(not(debug_assertions))]
+fn alloc_with_large_array() {
+    let b = Bump::new();
+
+    b.alloc_with(|| [4u8; 10_000_000]);
+}
+
+#[allow(dead_code)]
+#[cfg(not(debug_assertions))]
+struct LargeStruct {
+    small: usize,
+    big1: [u8; 20_000_000],
+    big2: [u8; 20_000_000],
+    big3: [u8; 20_000_000],
+}
+
+#[test]
+#[cfg(not(debug_assertions))]
+fn alloc_with_large_struct() {
+    let b = Bump::new();
+
+    b.alloc_with(|| LargeStruct {
+        small: 1,
+        big1: [2; 20_000_000],
+        big2: [3; 20_000_000],
+        big3: [4; 20_000_000],
+    });
+}
+
+#[test]
+#[cfg(not(debug_assertions))]
+fn alloc_with_large_tuple() {
+    let b = Bump::new();
+
+    b.alloc_with(|| {
+        (
+            1u32,
+            LargeStruct {
+                small: 2,
+                big1: [3; 20_000_000],
+                big2: [4; 20_000_000],
+                big3: [5; 20_000_000],
+            },
+        )
+    });
+}
+
+#[cfg(not(debug_assertions))]
+enum LargeEnum {
+    Small,
+    #[allow(dead_code)]
+    Large([u8; 10_000_000]),
+}
+
+#[test]
+#[cfg(not(debug_assertions))]
+fn alloc_with_large_enum() {
+    let b = Bump::new();
+
+    b.alloc_with(|| LargeEnum::Small);
+}

--- a/tests/alloc_with.rs
+++ b/tests/alloc_with.rs
@@ -1,8 +1,14 @@
+#![cfg(not(debug_assertions))]
+
 // All of these alloc_with tests will fail with "fatal runtime error: stack overflow" unless LLVM
 // manages to optimize the stack writes away.
+//
+// We only run them when debug_assertions are not set, as we expect them to fail outside release
+// mode.
+
+use bumpalo::Bump;
 
 #[test]
-#[cfg(not(debug_assertions))]
 fn alloc_with_large_array() {
     let b = Bump::new();
 
@@ -10,7 +16,6 @@ fn alloc_with_large_array() {
 }
 
 #[allow(dead_code)]
-#[cfg(not(debug_assertions))]
 struct LargeStruct {
     small: usize,
     big1: [u8; 20_000_000],
@@ -19,7 +24,6 @@ struct LargeStruct {
 }
 
 #[test]
-#[cfg(not(debug_assertions))]
 fn alloc_with_large_struct() {
     let b = Bump::new();
 
@@ -32,7 +36,6 @@ fn alloc_with_large_struct() {
 }
 
 #[test]
-#[cfg(not(debug_assertions))]
 fn alloc_with_large_tuple() {
     let b = Bump::new();
 
@@ -49,7 +52,6 @@ fn alloc_with_large_tuple() {
     });
 }
 
-#[cfg(not(debug_assertions))]
 enum LargeEnum {
     Small,
     #[allow(dead_code)]
@@ -57,7 +59,6 @@ enum LargeEnum {
 }
 
 #[test]
-#[cfg(not(debug_assertions))]
 fn alloc_with_large_enum() {
     let b = Bump::new();
 


### PR DESCRIPTION
This adds a functionality similar to the boxext or copyless crates, i.e.
it adds a function to allocate and write values directly to the heap
instead of going through the stack first.

Resolves #10.