### PR TITLE
Add `collect_in` for iterators.

### DIFF
--- a/tests/vec.rs
+++ b/tests/vec.rs
@@ -9,3 +9,10 @@ fn push_a_bunch_of_items() {
         v.push(x);
     }
 }
+
+#[test]
+fn collect_in_a_bump_arena() {
+    use bumpalo::collections::vec::{IteratorBump, Vec};
+    let b = Bump::new();
+    (0..10_000).collect_in::<Vec<_>>(&b);
+}


### PR DESCRIPTION
This adds an extension trait for a new iterator method `collect_in`, that allows using `collect` on a bump allocator.

I've made the PR to stimulate discussion, it didn't take very long so feel free to reject if you feel it doesn't fit.