### PR TITLE
Pass correct Layout to dealloc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,7 +228,7 @@ impl Drop for Bump {
             let mut footer = Some(self.all_chunk_footers.get());
             while let Some(f) = footer {
                 footer = f.as_ref().next.get();
-                dealloc(f.as_ref().data.as_ptr(), Bump::default_chunk_layout());
+                dealloc(f.as_ref().data.as_ptr(), f.as_ref().layout);
             }
         }
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -96,3 +96,12 @@ fn force_new_chunk_fits_well() {
     b.alloc_layout(Layout::from_size_align(100_001, 1).unwrap());
     b.alloc_layout(Layout::from_size_align(100_003, 1).unwrap());
 }
+
+#[test]
+fn alloc_with_strong_alignment() {
+    let b = Bump::new();
+
+    // 64 is probably the strongest alignment we'll see in practice
+    // e.g. AVX-512 types, or cache line padding optimizations
+    b.alloc_layout(Layout::from_size_align(4096, 64).unwrap());
+}


### PR DESCRIPTION
Fixes #19

`dealloc` was always being called with the default chunk layout rather than the one in the chunk footer.