### PR TITLE
Fix inaccurate documentation URL in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 categories = ["memory-management", "rust-patterns", "no-std"]
 description = "A fast bump allocation arena for Rust."
-documentation = "https://docs.rs/id-arena"
+documentation = "https://docs.rs/bumpalo"
 edition = "2018"
 license = "MIT/Apache-2.0"
 name = "bumpalo"


### PR DESCRIPTION
Thanks so much for this crate! I'm really enjoying using it.

I noticed the `documentation` link in `Cargol.toml` was pointing to https://docs.rs/id-arena - this changes it to https://docs.rs/bumpalo