### PR TITLE
Replace each_allocated_chunk function with iter_allocated_chunks function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -723,7 +723,7 @@ impl Bump {
     }
 }
 
-/// An iterator over the each chunk of allocated memory that
+/// An iterator over each chunk of allocated memory that
 /// an arena has bump allocated into.
 ///
 /// Chunks are returned in order of allocation: oldest chunks first, newest

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -667,7 +667,7 @@ impl Bump {
         }
     }
 
-    /// Returns an iterator over the each chunk of allocated memory that
+    /// Returns an iterator over each chunk of allocated memory that
     /// from an arena has bump allocated into.
     ///
     /// Chunks are returned in order of allocation: oldest chunks first, newest

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -724,7 +724,7 @@ impl Bump {
 }
 
 /// An iterator over the each chunk of allocated memory that
-/// from an arena has bump allocated into.
+/// an arena has bump allocated into.
 ///
 /// Chunks are returned in order of allocation: oldest chunks first, newest
 /// chunks last.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -668,7 +668,7 @@ impl Bump {
     }
 
     /// Returns an iterator over each chunk of allocated memory that
-    /// from an arena has bump allocated into.
+    /// this arena has bump allocated into.
     ///
     /// Chunks are returned in order of allocation: oldest chunks first, newest
     /// chunks last.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -730,7 +730,7 @@ impl Bump {
 /// chunks last.
 ///
 /// This struct is created by the [`iter_allocated_chunks`] method on
-/// [Bump]. See that function for a safety description regarding.
+/// [Bump]. See that function for a safety description regarding reading from the returned items.
 #[derive(Debug)]
 pub struct ChunkIter<'a> {
     footer: Option<NonNull<ChunkFooter>>,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -40,23 +40,22 @@ fn can_iterate_over_allocated_things() {
 
     // Safe because we always allocated objects of the same type in this arena,
     // and their size >= their align.
-    unsafe {
-        bump.each_allocated_chunk(|ch| {
-            let ch_usize = ch.as_ptr() as usize;
-            println!("iter chunk @ 0x{:x}", ch_usize);
-            assert_eq!(
-                chunks.pop().unwrap(),
-                ch_usize,
-                "should iterate over each chunk once, in order they were allocated in"
-            );
+    for ch in bump.iter_allocated_chunks() {
+        let ch_usize = ch.as_ptr() as usize;
+        println!("iter chunk @ 0x{:x}", ch_usize);
+        assert_eq!(
+            chunks.pop().unwrap(),
+            ch_usize,
+            "should iterate over each chunk once, in order they were allocated in"
+        );
 
-            let ch: &[u64] =
-                slice::from_raw_parts(ch.as_ptr() as *mut u64, ch.len() / mem::size_of::<u64>());
-            for i in ch {
-                assert!(*i < MAX, "{} < {} (aka {:x} < {:x})", i, MAX, i, MAX);
-                seen[*i as usize] = true;
-            }
-        });
+        let ch: &[u64] = unsafe {
+            slice::from_raw_parts(ch.as_ptr() as *mut u64, ch.len() / mem::size_of::<u64>())
+        };
+        for i in ch {
+            assert!(*i < MAX, "{} < {} (aka {:x} < {:x})", i, MAX, i, MAX);
+            seen[*i as usize] = true;
+        }
     }
 
     assert!(seen.iter().all(|s| *s));


### PR DESCRIPTION
This implements the suggestion in #27.