### PR TITLE
Lint cleanup

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -1,5 +1,3 @@
-extern crate criterion;
-
 use criterion::{criterion_group, criterion_main, Criterion, ParameterizedBenchmark, Throughput};
 
 #[derive(Default)]
@@ -27,7 +25,7 @@ fn alloc<T: Default>(n: usize) {
 fn alloc_with<T: Default>(n: usize) {
     let arena = bumpalo::Bump::new();
     for _ in 0..n {
-        let val: &mut T = arena.alloc_with(|| Default::default());
+        let val: &mut T = arena.alloc_with(Default::default);
         criterion::black_box(val);
     }
 }

--- a/src/collections/raw_vec.rs
+++ b/src/collections/raw_vec.rs
@@ -113,11 +113,7 @@ impl<'a, T> RawVec<'a, T> {
                 }
             };
 
-            RawVec {
-                ptr: ptr.into(),
-                cap,
-                a,
-            }
+            RawVec { ptr, cap, a }
         }
     }
 }
@@ -251,11 +247,9 @@ impl<'a, T> RawVec<'a, T> {
                     let new_cap = 2 * self.cap;
                     let new_size = new_cap * elem_size;
                     alloc_guard(new_size).unwrap_or_else(|_| capacity_overflow());
-                    let ptr_res = self
-                        .a
-                        .realloc(NonNull::from(self.ptr).cast(), cur, new_size);
+                    let ptr_res = self.a.realloc(self.ptr.cast(), cur, new_size);
                     match ptr_res {
-                        Ok(ptr) => (new_cap, ptr.cast().into()),
+                        Ok(ptr) => (new_cap, ptr.cast()),
                         Err(_) => handle_alloc_error(Layout::from_size_align_unchecked(
                             new_size,
                             cur.align(),
@@ -267,7 +261,7 @@ impl<'a, T> RawVec<'a, T> {
                     // would cause overflow
                     let new_cap = if elem_size > (!0) / 8 { 1 } else { 4 };
                     match self.a.alloc_array::<T>(new_cap) {
-                        Ok(ptr) => (new_cap, ptr.into()),
+                        Ok(ptr) => (new_cap, ptr),
                         Err(_) => handle_alloc_error(Layout::array::<T>(new_cap).unwrap()),
                     }
                 }
@@ -313,10 +307,7 @@ impl<'a, T> RawVec<'a, T> {
             let new_cap = 2 * self.cap;
             let new_size = new_cap * elem_size;
             alloc_guard(new_size).unwrap_or_else(|_| capacity_overflow());
-            match self
-                .a
-                .grow_in_place(NonNull::from(self.ptr).cast(), old_layout, new_size)
-            {
+            match self.a.grow_in_place(self.ptr.cast(), old_layout, new_size) {
                 Ok(_) => {
                     // We can't directly divide `size`.
                     self.cap = new_cap;
@@ -496,11 +487,10 @@ impl<'a, T> RawVec<'a, T> {
             let new_layout = Layout::new::<T>().repeat(new_cap).unwrap().0;
             // FIXME: may crash and burn on over-reserve
             alloc_guard(new_layout.size()).unwrap_or_else(|_| capacity_overflow());
-            match self.a.grow_in_place(
-                NonNull::from(self.ptr).cast(),
-                old_layout,
-                new_layout.size(),
-            ) {
+            match self
+                .a
+                .grow_in_place(self.ptr.cast(), old_layout, new_layout.size())
+            {
                 Ok(_) => {
                     self.cap = new_cap;
                     true
@@ -558,11 +548,8 @@ impl<'a, T> RawVec<'a, T> {
                 let new_size = elem_size * amount;
                 let align = mem::align_of::<T>();
                 let old_layout = Layout::from_size_align_unchecked(old_size, align);
-                match self
-                    .a
-                    .realloc(NonNull::from(self.ptr).cast(), old_layout, new_size)
-                {
-                    Ok(p) => self.ptr = p.cast().into(),
+                match self.a.realloc(self.ptr.cast(), old_layout, new_size) {
+                    Ok(p) => self.ptr = p.cast(),
                     Err(_) => {
                         handle_alloc_error(Layout::from_size_align_unchecked(new_size, align))
                     }
@@ -623,18 +610,16 @@ impl<'a, T> RawVec<'a, T> {
             let res = match self.current_layout() {
                 Some(layout) => {
                     debug_assert!(new_layout.align() == layout.align());
-                    self.a
-                        .realloc(NonNull::from(self.ptr).cast(), layout, new_layout.size())
+                    self.a.realloc(self.ptr.cast(), layout, new_layout.size())
                 }
                 None => Alloc::alloc(&mut self.a, new_layout),
             };
 
-            match (&res, fallibility) {
-                (Err(AllocErr), Infallible) => handle_alloc_error(new_layout),
-                _ => {}
+            if let (Err(AllocErr), Infallible) = (&res, fallibility) {
+                handle_alloc_error(new_layout);
             }
 
-            self.ptr = res?.cast().into();
+            self.ptr = res?.cast();
             self.cap = new_cap;
 
             Ok(())
@@ -648,7 +633,7 @@ impl<'a, T> RawVec<'a, T> {
         let elem_size = mem::size_of::<T>();
         if elem_size != 0 {
             if let Some(layout) = self.current_layout() {
-                self.a.dealloc(NonNull::from(self.ptr).cast(), layout);
+                self.a.dealloc(self.ptr.cast(), layout);
             }
         }
     }

--- a/src/collections/str/lossy.rs
+++ b/src/collections/str/lossy.rs
@@ -12,20 +12,19 @@ use crate::collections::str as core_str;
 use core::char;
 use core::fmt;
 use core::fmt::Write;
-use core::mem;
 use core::str;
 
 /// Lossy UTF-8 string.
-pub struct Utf8Lossy {
-    bytes: [u8],
+pub struct Utf8Lossy<'a> {
+    bytes: &'a [u8],
 }
 
-impl Utf8Lossy {
-    pub fn from_bytes(bytes: &[u8]) -> &Utf8Lossy {
-        unsafe { mem::transmute(bytes) }
+impl<'a> Utf8Lossy<'a> {
+    pub fn from_bytes(bytes: &'a [u8]) -> Utf8Lossy<'a> {
+        Utf8Lossy { bytes }
     }
 
-    pub fn chunks(&self) -> Utf8LossyChunksIter {
+    pub fn chunks(&self) -> Utf8LossyChunksIter<'a> {
         Utf8LossyChunksIter {
             source: &self.bytes,
         }
@@ -52,7 +51,7 @@ impl<'a> Iterator for Utf8LossyChunksIter<'a> {
     type Item = Utf8LossyChunk<'a>;
 
     fn next(&mut self) -> Option<Utf8LossyChunk<'a>> {
-        if self.source.len() == 0 {
+        if self.source.is_empty() {
             return None;
         }
 
@@ -150,11 +149,11 @@ impl<'a> Iterator for Utf8LossyChunksIter<'a> {
     }
 }
 
-impl fmt::Display for Utf8Lossy {
+impl<'a> fmt::Display for Utf8Lossy<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // If we're the empty string then our iterator won't actually yield
         // anything, so perform the formatting manually
-        if self.bytes.len() == 0 {
+        if self.bytes.is_empty() {
             return "".fmt(f);
         }
 
@@ -176,7 +175,7 @@ impl fmt::Display for Utf8Lossy {
     }
 }
 
-impl fmt::Debug for Utf8Lossy {
+impl<'a> fmt::Debug for Utf8Lossy<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_char('"')?;
 

--- a/src/collections/string.rs
+++ b/src/collections/string.rs
@@ -220,11 +220,9 @@ macro_rules! format {
 ///
 /// fn example_func<A: TraitExample>(example_arg: A) {}
 ///
-/// fn main() {
-///     let b = Bump::new();
-///     let example_string = String::from_str_in("example_string", &b);
-///     example_func(&example_string);
-/// }
+/// let b = Bump::new();
+/// let example_string = String::from_str_in("example_string", &b);
+/// example_func(&example_string);
 /// ```
 ///
 /// There are two options that would work instead. The first would be to
@@ -644,7 +642,7 @@ impl<'bump> String<'bump> {
             return String::from_str_in("", bump);
         };
 
-        const REPLACEMENT: &'static str = "\u{FFFD}";
+        const REPLACEMENT: &str = "\u{FFFD}";
 
         let mut res = String::with_capacity_in(v.len(), bump);
         res.push_str(first_valid);
@@ -1509,14 +1507,12 @@ impl<'bump> String<'bump> {
     /// ```
     /// use bumpalo::{Bump, collections::String};
     ///
-    /// # fn main() {
     /// let b = Bump::new();
     ///
     /// let mut hello = String::from_str_in("Hello, World!", &b);
     /// let world = hello.split_off(7);
     /// assert_eq!(hello, "Hello, ");
     /// assert_eq!(world, "World!");
-    /// # }
     /// ```
     #[inline]
     pub fn split_off(&mut self, at: usize) -> String<'bump> {
@@ -1835,10 +1831,6 @@ impl<'bump> PartialEq for String<'bump> {
     fn eq(&self, other: &String) -> bool {
         PartialEq::eq(&self[..], &other[..])
     }
-    #[inline]
-    fn ne(&self, other: &String) -> bool {
-        PartialEq::ne(&self[..], &other[..])
-    }
 }
 
 macro_rules! impl_eq {
@@ -1848,20 +1840,12 @@ macro_rules! impl_eq {
             fn eq(&self, other: &$rhs) -> bool {
                 PartialEq::eq(&self[..], &other[..])
             }
-            #[inline]
-            fn ne(&self, other: &$rhs) -> bool {
-                PartialEq::ne(&self[..], &other[..])
-            }
         }
 
         impl<'a, 'b, 'bump> PartialEq<$lhs> for $rhs {
             #[inline]
             fn eq(&self, other: &$lhs) -> bool {
                 PartialEq::eq(&self[..], &other[..])
-            }
-            #[inline]
-            fn ne(&self, other: &$lhs) -> bool {
-                PartialEq::ne(&self[..], &other[..])
             }
         }
     };

--- a/tests/quickchecks.rs
+++ b/tests/quickchecks.rs
@@ -1,6 +1,3 @@
-extern crate bumpalo;
-extern crate quickcheck;
-
 use bumpalo::Bump;
 use quickcheck::{quickcheck, Arbitrary, Gen};
 use std::mem;

--- a/tests/string.rs
+++ b/tests/string.rs
@@ -1,4 +1,3 @@
-extern crate bumpalo;
 use bumpalo::{collections::String, Bump};
 use std::fmt::Write;
 

--- a/tests/vec.rs
+++ b/tests/vec.rs
@@ -1,4 +1,3 @@
-extern crate bumpalo;
 use bumpalo::{collections::Vec, Bump};
 
 #[test]


### PR DESCRIPTION
This commit fixes all of the clippy warnings in the project.

Initially `cargo +nightly fix -Z unstable-options --clippy` was run to
fix most issues. The rest were fixed by hand.