### PR TITLE
Always compile as a no_std crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,11 @@ quickcheck = "0.8.2"
 criterion = "0.2.10"
 
 [features]
-default = ["collections", "std"]
-collections = ["std"]
+default = ["collections"]
+collections = []
+
+# This feature is only included for backwards compatibility and
+# no longer has any effect
 std = []
 
 # [profile.bench]

--- a/README.md
+++ b/README.md
@@ -93,11 +93,5 @@ this `collections` module and use the `std` versions.
 
 ### `#![no_std]` Support
 
-Requires the `alloc` nightly feature. Disable the on-by-default `"std"` feature:
-
-```toml
-[dependencies.bumpalo]
-version = "1"
-default-features = false
-```
+Bumpalo is a `no_std` crate. It depends only on the `alloc` and `core` crates.
 

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -30,6 +30,7 @@ fn alloc_with<T: Default>(n: usize) {
     }
 }
 
+#[cfg(feature = "collections")]
 fn format_realloc(bump: &bumpalo::Bump, n: usize) {
     let n = criterion::black_box(n);
     let s = bumpalo::format!(in bump, "Hello {:.*}", n, "World! ");
@@ -97,6 +98,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         .throughput(|n| Throughput::Elements(*n as u32)),
     );
 
+    #[cfg(feature = "collections")]
     c.bench(
         "format-realloc",
         ParameterizedBenchmark::new(

--- a/src/collections/string.rs
+++ b/src/collections/string.rs
@@ -59,7 +59,8 @@
 //! assert_eq!(bytes, [240, 159, 146, 150]);
 //! ```
 
-use super::str::lossy;
+use crate::collections::str::lossy;
+use crate::collections::vec::Vec;
 use crate::Bump;
 use core::char::decode_utf16;
 use core::fmt;
@@ -69,10 +70,8 @@ use core::mem;
 use core::ops::Bound::{Excluded, Included, Unbounded};
 use core::ops::{self, Add, AddAssign, Index, IndexMut, RangeBounds};
 use core::ptr;
-
-use crate::collections::vec::Vec;
-use std::borrow::Cow;
-use std::str::{self, Chars, Utf8Error};
+use core::str::{self, Chars, Utf8Error};
+use core_alloc::borrow::Cow;
 
 /// Like the `format!` macro for creating `std::string::String`s but for
 /// `bumpalo::collections::String`.
@@ -1810,8 +1809,8 @@ impl<'bump> Extend<String<'bump>> for String<'bump> {
     }
 }
 
-impl<'bump> Extend<::std::string::String> for String<'bump> {
-    fn extend<I: IntoIterator<Item = ::std::string::String>>(&mut self, iter: I) {
+impl<'bump> Extend<core_alloc::string::String> for String<'bump> {
+    fn extend<I: IntoIterator<Item = core_alloc::string::String>>(&mut self, iter: I) {
         for s in iter {
             self.push_str(&s)
         }
@@ -1854,7 +1853,7 @@ macro_rules! impl_eq {
 impl_eq! { String<'bump>, str }
 impl_eq! { String<'bump>, &'a str }
 impl_eq! { Cow<'a, str>, String<'bump> }
-impl_eq! { ::std::string::String, String<'bump> }
+impl_eq! { core_alloc::string::String, String<'bump> }
 
 impl<'bump> fmt::Display for String<'bump> {
     #[inline]

--- a/src/collections/vec.rs
+++ b/src/collections/vec.rs
@@ -96,7 +96,7 @@ use core::ops::Bound::{Excluded, Included, Unbounded};
 use core::ops::{Index, IndexMut, RangeBounds};
 use core::ptr;
 use core::ptr::NonNull;
-use std::slice;
+use core::slice;
 
 unsafe fn arith_offset<T>(p: *const T, offset: isize) -> *const T {
     p.offset(offset)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,8 @@ collection types are modified to allocate their space inside `bumpalo::Bump`
 arenas.
 
 ```rust
+# #[cfg(feature = "collections")]
+# {
 use bumpalo::{Bump, collections::Vec};
 
 // Create a new bump arena.
@@ -84,6 +86,7 @@ let mut v = Vec::new_in(&bump);
 for i in 0..100 {
     v.push(i);
 }
+# }
 ```
 
 Eventually [all `std` collection types will be parameterized by an
@@ -92,58 +95,29 @@ this `collections` module and use the `std` versions.
 
 ## `#![no_std]` Support
 
-Requires the `alloc` nightly feature. Disable the on-by-default `"std"` feature:
-
-```toml
-[dependencies.bumpalo]
-version = "1"
-default-features = false
-```
+Bumpalo is a `no_std` crate. It depends only on the `alloc` and `core` crates.
 
  */
 
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
-// In no-std mode, use the alloc crate to get `Vec`.
-#![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
+#![no_std]
 
-#[cfg(feature = "std")]
-extern crate core;
+extern crate alloc as core_alloc;
 
 #[cfg(feature = "collections")]
 pub mod collections;
 
 mod alloc;
 
-#[cfg(feature = "std")]
-mod imports {
-    pub use std::alloc::{alloc, dealloc, Layout};
-    pub use std::cell::{Cell, UnsafeCell};
-    pub use std::cmp;
-    pub use std::fmt;
-    pub use std::iter;
-    pub use std::marker::PhantomData;
-    pub use std::mem;
-    pub use std::ptr::{self, NonNull};
-    pub use std::slice;
-}
-
-#[cfg(not(feature = "std"))]
-mod imports {
-    extern crate alloc;
-    pub use self::alloc::alloc::{alloc, dealloc, Layout};
-    pub use core::cell::{Cell, UnsafeCell};
-    pub use core::cmp;
-    pub use core::fmt;
-    pub use core::iter;
-    pub use core::marker::PhantomData;
-    pub use core::mem;
-    pub use core::ptr::{self, NonNull};
-    pub use core::slice;
-}
-
-use crate::imports::*;
+use core::cell::Cell;
+use core::cmp;
+use core::iter;
+use core::marker::PhantomData;
+use core::mem;
+use core::ptr::{self, NonNull};
+use core::slice;
+use core_alloc::alloc::{alloc, dealloc, Layout};
 
 /// An arena to bump allocate into.
 ///

--- a/tests/string.rs
+++ b/tests/string.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "collections")]
 use bumpalo::{collections::String, Bump};
 use std::fmt::Write;
 

--- a/tests/vec.rs
+++ b/tests/vec.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "collections")]
 use bumpalo::{collections::Vec, Bump};
 
 #[test]


### PR DESCRIPTION
This PR turns changes the `std` feature flag to do nothing, and always compiles as a `no_std` crate.

It also enables all code to compile and run with `--no-default-features` and with `--all-features`. Before this commit, running e.g. `cargo test --no-default-features` would fail both on stable and nightly.

Note that this introduces a bit of noise in the output when running `cargo test`. It looks like this: 

`error: no global memory allocator found but one is required [...]`

Now obviously this looks like it's an error, but it is actually safe to ignore does not actually affect the tests at all. See [this comment](https://github.com/rust-lang/rust/issues/54010#issuecomment-520221353) for more context.

Note also, that nightly clippy gives two additional warnings about doctests in `raw_vec.rs`. I chose to ignore these, as the tests do not actually work as far as I can tell, are not actually run (they are `ignore`) and are they part of any public interface.

I promise this is the last PR I will bother you with for now. :wink: