### PR TITLE
Make sure to align pointers in `alloc_layout_slow`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -636,6 +636,10 @@ impl Bump {
             let current_layout = current_footer.as_ref().layout;
             let new_footer =
                 Bump::new_chunk(Some((current_layout.size(), layout)), Some(current_footer));
+            debug_assert_eq!(
+                new_footer.as_ref().data.as_ptr() as usize % layout.align(),
+                0
+            );
 
             // Set the new chunk as our new current chunk.
             self.current_chunk_footer.set(new_footer);
@@ -646,6 +650,8 @@ impl Bump {
             // this can't overflow because we successfully allocated a chunk of
             // at least the requested size.
             let ptr = new_footer.ptr.get().as_ptr() as usize - size;
+            // Round the pointer down to the requested alignment.
+            let ptr = ptr & !(layout.align() - 1);
             debug_assert!(
                 ptr <= new_footer as *const _ as usize,
                 "{:#x} <= {:#x}",

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -180,3 +180,15 @@ fn test_reset() {
     );
     assert_eq!(b.iter_allocated_chunks().count(), 1);
 }
+
+#[test]
+fn test_alignment() {
+    let b = Bump::new();
+
+    let layout = std::alloc::Layout::from_size_align(64, 64).unwrap();
+
+    for _ in 0..1024 {
+        let ptr = b.alloc_layout(layout).as_ptr();
+        assert_eq!(ptr as *const u8 as usize % 64, 0);
+    }
+}


### PR DESCRIPTION
We didn't used to need to align pointers in `alloc_layout_slow` when we were bumping upwards, since we made sure that the chunk itself had the proper alignment, and we were using the start of the chunk for this allocation. Now that we are bumping downwards, we need to round down to the proper alignment.

Fixes #43

cc @TethysSvensson 