### PR TITLE
Fixes for #46 by always aligning the requested memory to 16 bytes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -959,7 +959,7 @@ mod tests {
         use crate::alloc::Alloc;
 
         unsafe {
-            const CAPACITY: usize = 1024;
+            const CAPACITY: usize = 1024 - OVERHEAD;
             let mut b = Bump::with_capacity(CAPACITY);
 
             // `realloc` doesn't shrink allocations that aren't "worth it".

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,18 +224,17 @@ pub(crate) fn round_up_to(n: usize, divisor: usize) -> Option<usize> {
     Some(n.checked_add(divisor - 1)? & !(divisor - 1))
 }
 
-// We need a const fn for max
-const fn max(a: usize, b: usize) -> usize {
-    [a, b][(a < b) as usize]
-}
-
 // After this point, we try to hit page boundaries instead of powers of 2
 const PAGE_STRATEGY_CUTOFF: usize = 0x1000;
 
 // We only support alignments of up to 16 bytes for iter_allocated_chunks.
 const SUPPORTED_ITER_ALIGNMENT: usize = 16;
-const CHUNK_ALIGN: usize = max(SUPPORTED_ITER_ALIGNMENT, mem::align_of::<ChunkFooter>());
+const CHUNK_ALIGN: usize = SUPPORTED_ITER_ALIGNMENT;
 const FOOTER_SIZE: usize = mem::size_of::<ChunkFooter>();
+
+// Assert that ChunkFooter is at most the supported alignment. This will give a compile time error if it is not the case
+const _FOOTER_ALIGN_ASSERTION: bool = mem::align_of::<ChunkFooter>() <= CHUNK_ALIGN;
+const _: [(); _FOOTER_ALIGN_ASSERTION as usize] = [()];
 
 // Maximum typical overhead per allocation imposed by allocators.
 const MALLOC_OVERHEAD: usize = 16;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,17 +240,6 @@ const FOOTER_SIZE: usize = mem::size_of::<ChunkFooter>();
 // Maximum typical overhead per allocation imposed by allocators.
 const MALLOC_OVERHEAD: usize = 16;
 
-// Choose a relatively small default initial chunk size, since we double chunk
-// sizes as we grow bump arenas to amortize costs of hitting the global
-// allocator.
-const FIRST_ALLOCATION_GOAL: usize = (1 << 9) - MALLOC_OVERHEAD;
-
-// The actual size of the first allocation is going to be a bit smaller
-// than the goal. We need to make room for the footer, and we also need
-// take the alignment into account.
-const DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER: usize =
-    (FIRST_ALLOCATION_GOAL - FOOTER_SIZE) & !(CHUNK_ALIGN - 1);
-
 // This is the overhead from malloc, footer and alignment. For instance, if
 // we want to request a chunk of memory that has at least X bytes usable for
 // allocations (where X is aligned to CHUNK_ALIGN), then we expect that the
@@ -258,6 +247,16 @@ const DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER: usize =
 // the allocator actually sets asside for us is X+OVERHEAD rounded up to the
 // nearest suitable size boundary.
 const OVERHEAD: usize = (MALLOC_OVERHEAD + FOOTER_SIZE + (CHUNK_ALIGN - 1)) & !(CHUNK_ALIGN - 1);
+
+// Choose a relatively small default initial chunk size, since we double chunk
+// sizes as we grow bump arenas to amortize costs of hitting the global
+// allocator.
+const FIRST_ALLOCATION_GOAL: usize = (1 << 9);
+
+// The actual size of the first allocation is going to be a bit smaller
+// than the goal. We need to make room for the footer, and we also need
+// take the alignment into account.
+const DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER: usize = FIRST_ALLOCATION_GOAL - OVERHEAD;
 
 /// Wrapper around `Layout::from_size_align` that adds debug assertions.
 #[inline]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -183,12 +183,13 @@ fn test_reset() {
 
 #[test]
 fn test_alignment() {
-    let b = Bump::new();
+    for &alignment in &[2, 4, 8, 16, 32, 64] {
+        let b = Bump::with_capacity(513);
+        let layout = std::alloc::Layout::from_size_align(alignment, alignment).unwrap();
 
-    let layout = std::alloc::Layout::from_size_align(64, 64).unwrap();
-
-    for _ in 0..1024 {
-        let ptr = b.alloc_layout(layout).as_ptr();
-        assert_eq!(ptr as *const u8 as usize % 64, 0);
+        for _ in 0..1024 {
+            let ptr = b.alloc_layout(layout).as_ptr();
+            assert_eq!(ptr as *const u8 as usize % alignment, 0);
+        }
     }
 }


### PR DESCRIPTION
Before this commit, it was not safe to use iter_allocated_chunks if you
had allocated objects with a larger alignment that size_of::<usize>(),
even though the documentation did not mention this. #46 is about that bug.

This commit chooses to partially remedy this problem, and partially
update the documentation.

Specifically this commit fixes the code, so that alignments up to and
included 16 bytes are supported, but larger alignments will still cause
problems. It also updates the documentation, to specify that larger
alignments are unsupported when used together with
iter_allocated_chunks.

We do not believe this to be an issue, since we do not believe that
anybody using bumpalo will have alignment requirements larger than 16
bytes and also want to use iter_allocated_chunks.