### PR TITLE
Bump::alloc_str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Add `alloc_str`, which is similar to `alloc_slice_*` methods, but works on
+  string slices.
+
 # 2.6.0
 
 Released 2019-08-19.

--- a/tests/quickchecks.rs
+++ b/tests/quickchecks.rs
@@ -219,4 +219,12 @@ quickcheck! {
             allocated.push(range);
         }
     }
+
+    fn alloc_strs(allocs: Vec<String>) -> () {
+        let b = Bump::new();
+        let allocated: Vec<&str> = allocs.iter().map(|s| b.alloc_str(s) as &_).collect();
+        for (val, alloc) in allocs.into_iter().zip(allocated) {
+            assert_eq!(val, alloc);
+        }
+    }
 }


### PR DESCRIPTION
This is similar to allocating slices, but for string slices. Because
string slices are a strange beast and none of the other methods can be
used *directly*. It could be done at the caller side, but then the user
would need to use `unsafe` which might be unacceptable in business-logic
applications or crates (or be content with the needless check for utf8
which is already guaranteed to be valid).