### PR TITLE
Fix `vec!` macro requiring extra comma.

### DIFF
--- a/src/collections/vec.rs
+++ b/src/collections/vec.rs
@@ -264,7 +264,7 @@ macro_rules! vec {
         $( v.push($x); )*
         v
     }};
-    (in $bump:expr; $(, $x:expr,)*) => (bumpalo::vec![in $bump; $($x),*])
+    (in $bump:expr; $($x:expr,)*) => (bumpalo::vec![in $bump; $($x),*])
 }
 
 /// A contiguous growable array type, written `Vec<'bump, T>` but pronounced 'vector'.


### PR DESCRIPTION
Fix bug in `vec!` macro. (I assume it's a bug since it requires a strange extra comma).

Closes #59 