### PR TITLE
[WIP] Added try_alloc_layout, try_reserve, & try_reserve_exact

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,7 @@ version = "3.2.1"
 dependencies = [
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ required-features = ["collections"]
 [dev-dependencies]
 quickcheck = "0.9.0"
 criterion = "0.3.0"
+rand = "0.7"
 
 [features]
 default = []

--- a/src/collections/vec.rs
+++ b/src/collections/vec.rs
@@ -85,6 +85,7 @@
 
 use super::raw_vec::RawVec;
 use crate::Bump;
+use crate::collections::CollectionAllocErr;
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{self, Hash};
@@ -736,6 +737,22 @@ impl<'bump, T: 'bump> Vec<'bump, T> {
     /// ```
     pub fn reserve_exact(&mut self, additional: usize) {
         self.buf.reserve_exact(self.len, additional);
+    }
+
+    /// TODO
+    pub fn try_reserve(
+        &mut self,
+        additional: usize,
+    ) -> Result<(), CollectionAllocErr> {
+        self.buf.try_reserve(self.len, additional)
+    }
+
+    /// TODO
+    pub fn try_reserve_exact(
+        &mut self,
+        additional: usize,
+    ) -> Result<(), CollectionAllocErr> {
+        self.buf.try_reserve_exact(self.len, additional)
     }
 
     /// Shrinks the capacity of the vector as much as possible.

--- a/src/collections/vec.rs
+++ b/src/collections/vec.rs
@@ -739,7 +739,26 @@ impl<'bump, T: 'bump> Vec<'bump, T> {
         self.buf.reserve_exact(self.len, additional);
     }
 
-    /// TODO
+    /// Attempts to reserve capacity for at least `additional` more elements to be inserted
+    /// in the given `Vec<'bump, T>`. The collection may reserve more space to avoid
+    /// frequent reallocations. After calling `try_reserve`, capacity will be
+    /// greater than or equal to `self.len() + additional`. Does nothing if
+    /// capacity is already sufficient.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity overflows `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bumpalo::{Bump, collections::Vec};
+    ///
+    /// let b = Bump::new();
+    /// let mut vec = bumpalo::vec![in &b; 1];
+    /// vec.try_reserve(10).unwrap();
+    /// assert!(vec.capacity() >= 11);
+    /// ```
     pub fn try_reserve(
         &mut self,
         additional: usize,
@@ -747,7 +766,29 @@ impl<'bump, T: 'bump> Vec<'bump, T> {
         self.buf.try_reserve(self.len, additional)
     }
 
-    /// TODO
+    /// Attempts to reserve the minimum capacity for exactly `additional` more elements to
+    /// be inserted in the given `Vec<'bump, T>`. After calling `try_reserve_exact`,
+    /// capacity will be greater than or equal to `self.len() + additional`.
+    /// Does nothing if the capacity is already sufficient.
+    ///
+    /// Note that the allocator may give the collection more space than it
+    /// requests. Therefore capacity can not be relied upon to be precisely
+    /// minimal. Prefer `try_reserve` if future insertions are expected.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity overflows `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bumpalo::{Bump, collections::Vec};
+    ///
+    /// let b = Bump::new();
+    /// let mut vec = bumpalo::vec![in &b; 1];
+    /// vec.try_reserve_exact(10).unwrap();
+    /// assert!(vec.capacity() >= 11);
+    /// ```
     pub fn try_reserve_exact(
         &mut self,
         additional: usize,

--- a/tests/try_alloc.rs
+++ b/tests/try_alloc.rs
@@ -1,0 +1,74 @@
+use bumpalo::Bump;
+use rand::Rng;
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::error::Error;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+struct Allocator(AtomicBool);
+
+impl Allocator {
+    fn is_returning_null(&self) -> bool {
+        self.0.load(Ordering::Relaxed)
+    }
+
+    fn toggle_state(&self) {
+        let current = self.0.load(Ordering::Relaxed);
+
+        self.0.store(!current, Ordering::Relaxed)
+    }
+}
+
+unsafe impl GlobalAlloc for Allocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if self.is_returning_null() {
+            core::ptr::null_mut()
+        } else {
+            SYSTEM_ALLOCATOR.alloc(layout)
+        }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if !self.is_returning_null() {
+            SYSTEM_ALLOCATOR.dealloc(ptr, layout);
+        }
+    }
+
+    unsafe fn realloc(
+        &self,
+        ptr: *mut u8,
+        layout: Layout,
+        new_size: usize
+    ) -> *mut u8 {
+        if self.is_returning_null() {
+            core::ptr::null_mut()
+        } else {
+            SYSTEM_ALLOCATOR.realloc(ptr, layout, new_size)
+        }
+    }
+}
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: Allocator = Allocator(AtomicBool::new(false));
+static SYSTEM_ALLOCATOR: System = System;
+
+#[test]
+fn test_alt_allocations() -> Result<(), Box<dyn Error>> {
+    const NUM_TESTS: usize = 32;
+
+    let bump = Bump::try_new().unwrap();
+    let mut rng = rand::thread_rng();
+    let layout = Layout::from_size_align(2, 2)?;
+
+    for i in 0..NUM_TESTS {
+        if rng.gen() {
+            GLOBAL_ALLOCATOR.toggle_state();
+        } else if GLOBAL_ALLOCATOR.is_returning_null() {
+            assert!(bump.try_alloc_layout(layout).is_err());
+        } else {
+            assert!(bump.try_alloc_layout(layout).is_ok());
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
1) Made it a point to not make any breaking changes to the public API.
2) I implemented my own global allocator which always returns a null ptr to simulate OOM and it seemed like `Bump::new()` /  `Bump::with_capacity(0)` would always panic with `oom()`. Shouldn't it not try and reach for the allocator in that case? Any idea how to go about fixing that special case?
3) I named the new methods `try_reserve` and `try_reserve_exact` to match what raw/vec calls them, but I could rename them to `try_alloc_in_new_chunk_if_necessary` like you suggested if you wish.

Fixes #66 