### PR TITLE
realloc: Copy `old_size` number of bytes (not `new_size`) into new allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,48 @@ Released YYYY-MM-DD.
 
 --------------------------------------------------------------------------------
 
+## 3.2.1
+
+Released 2020-03-24.
+
+### Security
+
+* When `realloc`ing, if we allocate new space, we need to copy the old
+  allocation's bytes into the new space. There are `old_size` number of bytes in
+  the old allocation, but we were accidentally copying `new_size` number of
+  bytes, which could lead to copying bytes into the realloc'd space from past
+  the chunk that we're bump allocating out of, from unknown memory.
+
+  If an attacker can cause `realloc`s, and can read the `realoc`ed data back,
+  this could allow them to read things from other regions of memory that they
+  shouldn't be able to. For example, if some crypto keys happened to live in
+  memory right after a chunk we were bump allocating out of, this could allow
+  the attacker to read the crypto keys.
+
+  Beyond just fixing the bug and adding a regression test, I've also taken two
+  additional steps:
+
+  1. While we were already running the testsuite under `valgrind` in CI, because
+     `valgrind` exits with the same code that the program did, if there are
+     invalid reads/writes that happen not to trigger a segfault, the program can
+     still exit OK and we will be none the wiser. I've enabled the
+     `--error-exitcode=1` flag for `valgrind` in CI so that tests eagerly fail
+     in these scenarios.
+
+  2. I've written a quickcheck test to exercise `realloc`. Without the bug fix
+     in this patch, this quickcheck immediately triggers invalid reads when run
+     under `valgrind`. We didn't previously have quickchecks that exercised
+     `realloc` beacuse `realloc` isn't publicly exposed directly, and instead
+     can only be indirectly called. This new quickcheck test exercises `realloc`
+     via `bumpalo::collections::Vec::resize` and
+     `bumpalo::collections::Vec::shrink_to_fit` calls.
+
+  This bug was introduced in version 3.0.0.
+
+  See [#69](https://github.com/fitzgen/bumpalo/issues/69) for details.
+
+--------------------------------------------------------------------------------
+
 ## 3.2.0
 
 Released 209-2-07.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT/Apache-2.0"
 name = "bumpalo"
 readme = "./README.md"
 repository = "https://github.com/fitzgen/bumpalo"
-version = "3.2.0"
+version = "3.2.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,8 @@ jobs:
       - bash: |
           set -ex
           export RUST_BACKTRACE=1
-          export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER=valgrind
+          # Don't leak-check, as Rust globals tend to cause false positives.
+          export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="valgrind --suppressions=valgrind.supp --leak-check=no --error-exitcode=1"
           cargo test
           cargo test --all-features
         displayName: "Run `cargo test` under Valgrind"

--- a/ci/install-cargo-readme.yml
+++ b/ci/install-cargo-readme.yml
@@ -1,14 +1,5 @@
 steps:
-  - script: |
-      (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
-    displayName: Install `cargo install-update`
-  - script: |
-      (test -x $HOME/.cargo/bin/cargo-readme || cargo install --vers "^3" cargo-readme)
+  - script: cargo install --vers "^3" cargo-readme
     displayName: Install `cargo readme`
-  - script: |
-      cargo install-update -a
-    displayName: Update `cargo install`ed binaries
-  - script: |
-      cargo install-update --version
-      cargo readme --version
-    displayName: Query `cargo install-update` and `cargo readme` versions
+  - script: cargo readme --version
+    displayName: Query `cargo readme` version

--- a/tests/vec.rs
+++ b/tests/vec.rs
@@ -50,7 +50,7 @@ fn recursive_vecs() {
 fn test_into_bump_slice_mut() {
     let b = Bump::new();
     let v = bumpalo::vec![in &b; 1, 2, 3];
-    let mut slice = v.into_bump_slice_mut();
+    let slice = v.into_bump_slice_mut();
 
     slice[0] = 3;
     slice[2] = 1;

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -1,0 +1,7 @@
+{
+   <oom_instead_of_bump_pointer_overflow has an expected malloc fishy value>
+   Memcheck:FishyValue
+   malloc(size)
+   fun:malloc
+   obj:/**/target/*/deps/tests-*
+}


### PR DESCRIPTION
When reallocating, if we allocate new space, we need to copy the old
allocation's bytes into the new space. There are `old_size` number of bytes in
the old allocation, but we were accidentally copying `new_size` number of bytes,
which could lead to copying bytes into the realloc'd space from past the chunk
that we're bump allocating out of, from unknown memory.

If an attacker can cause `realloc`s, and can read the `realoc`ed data back, this
could allow them to read things from other regions of memory that they shouldn't
be able to. For example, if some crypto keys happened to live in memory right
after a chunk we were bump allocating out of, this could allow the attacker to
read the crypto keys.

Beyond just fixing the bug and adding a regression test, I've also taken two
additional steps:

1. While we were already running the testsuite under `valgrind` in CI, because
`valgrind` exits with the same code that the program did, if there are invalid
reads/writes that happen not to trigger a segfault, the program can still exit
OK and we will be none the wiser. I've enabled the `--error-exitcode=1` flag for
`valgrind` in CI so that tests eagerly fail in these scenarios.

2. I've written a quickcheck test to exercise `realloc`. Without the bug fix in
this patch, this quickcheck immediately triggers invalid reads when run under
`valgrind`. We didn't previously have quickchecks that exercised `realloc`
beacuse `realloc` isn't publicly exposed directly, and instead can only be
indirectly called. This new quickcheck test exercises `realloc` via
`bumpalo::collections::Vec::resize` and
`bumpalo::collections::Vec::shrink_to_fit` calls.

Fixes #69
