### PR TITLE
Simplify code handling ZSTs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -817,18 +817,6 @@ impl Bump {
     #[inline(always)]
     fn try_alloc_layout_fast(&self, layout: Layout) -> Option<NonNull<u8>> {
         unsafe {
-            if layout.size() == 0 {
-                // We want to use NonNull::dangling here, but that function uses mem::align_of::<T>
-                // internally. For our use-case we cannot call dangling::<T>, since we are not generic
-                // over T; we only have access to the Layout of T. Instead we re-implement the
-                // functionality here.
-                //
-                // See https://github.com/rust-lang/rust/blob/9966af3/src/libcore/ptr/non_null.rs#L70
-                // for the reference implementation.
-                let ptr = layout.align() as *mut u8;
-                return Some(NonNull::new_unchecked(ptr));
-            }
-
             let footer = self.current_chunk_footer.get();
             let footer = footer.as_ref();
             let ptr = footer.ptr.get().as_ptr() as usize;
@@ -1081,7 +1069,7 @@ unsafe impl<'a> alloc::Alloc for &'a Bump {
     unsafe fn dealloc(&mut self, ptr: NonNull<u8>, layout: Layout) {
         // If the pointer is the last allocation we made, we can reuse the bytes,
         // otherwise they are simply leaked -- at least until somebody calls reset().
-        if layout.size() != 0 && self.is_last_allocation(ptr) {
+        if self.is_last_allocation(ptr) {
             let ptr = NonNull::new_unchecked(ptr.as_ptr().add(layout.size()));
             self.current_chunk_footer.get().as_ref().ptr.set(ptr);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -816,6 +816,10 @@ impl Bump {
 
     #[inline(always)]
     fn try_alloc_layout_fast(&self, layout: Layout) -> Option<NonNull<u8>> {
+        // We don't need to check for ZSTs here since they will automatically
+        // be handled properly: the pointer will be bumped by zero bytes,
+        // modulo alignment. This keeps the fast path optimized for non-ZSTs,
+        // which are much more common.
         unsafe {
             let footer = self.current_chunk_footer.get();
             let footer = footer.as_ref();

--- a/tests/alloc_fill.rs
+++ b/tests/alloc_fill.rs
@@ -16,10 +16,11 @@ fn alloc_slice_fill_zero() {
     b.alloc_slice_fill_copy(0, 42u64);
     b.alloc_slice_fill_clone(0, &"hello".to_string());
     b.alloc_slice_fill_default::<String>(0);
-    b.alloc(MyZeroSizedType);
+    let ptr2 = b.alloc(MyZeroSizedType);
+    assert_eq!(ptr1.as_ptr() as usize & !7, ptr2 as *mut _ as usize);
 
-    let ptr2 = b.alloc_layout(layout);
-    assert_eq!(ptr1.as_ptr() as usize, ptr2.as_ptr() as usize + 1);
+    let ptr3 = b.alloc_layout(layout);
+    assert_eq!(ptr2 as *mut _ as usize, ptr3.as_ptr() as usize + 1);
 }
 
 #[test]


### PR DESCRIPTION
Allocation of ZSTs is very rare, so remove checks for zero-sized
layouts in the fast path and instead just use the normal code path
which will bump the pointer by zero bytes.