### PR TITLE
Add collect_in for iterators

### DIFF
--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -590,7 +590,7 @@ impl<'a, I: FusedIterator + ?Sized> FusedIterator for Box<'a, I> {}
 #[cfg(feature = "collections")]
 impl<'a, A> Box<'a, [A]> {
     /// Creates a value from an iterator.
-    /// This method is adapted version of `FromIterator::from_iter`.
+    /// This method is an adapted version of `FromIterator::from_iter`.
     /// It cannot be made as that trait implementation given different signature.
     ///
     /// # Examples
@@ -610,6 +610,18 @@ impl<'a, A> Box<'a, [A]> {
         let mut vec = Vec::new_in(a);
         vec.extend(iter);
         vec.into_boxed_slice()
+    }
+}
+
+#[cfg(feature = "collections")]
+#[deny(unconditional_recursion)]
+impl<'a, A> crate::iter::FromIteratorIn<'a, A> for Box<'a, [A]> {
+    #[inline]
+    fn from_iter_in<T>(iter: T, a: &'a Bump) -> Self
+    where
+        T: IntoIterator<Item = A>,
+    {
+        Self::from_iter_in(iter, a)
     }
 }
 

--- a/src/collections/string.rs
+++ b/src/collections/string.rs
@@ -61,6 +61,7 @@
 
 use crate::collections::str::lossy;
 use crate::collections::vec::Vec;
+use crate::iter::FromIteratorIn;
 use crate::Bump;
 use core::char::decode_utf16;
 use core::fmt;
@@ -1826,6 +1827,17 @@ impl<'a, 'bump> Extend<Cow<'a, str>> for String<'bump> {
         for s in iter {
             self.push_str(&s)
         }
+    }
+}
+
+impl<'bump, T> FromIteratorIn<'bump, T> for String<'bump>
+where
+    Self: Extend<T>,
+{
+    fn from_iter_in<I: IntoIterator<Item = T>>(iter: I, bump: &'bump Bump) -> Self {
+        let mut s = String::new_in(bump);
+        s.extend(iter);
+        s
     }
 }
 

--- a/src/collections/vec.rs
+++ b/src/collections/vec.rs
@@ -85,6 +85,7 @@
 
 use super::raw_vec::RawVec;
 use crate::collections::CollectionAllocErr;
+use crate::iter::FromIteratorIn;
 use crate::Bump;
 use core::cmp::Ordering;
 use core::fmt;
@@ -1892,6 +1893,14 @@ impl<'bump, T: 'bump> Extend<T> for Vec<'bump, T> {
         for t in iter {
             self.push(t);
         }
+    }
+}
+
+impl<'bump, T> FromIteratorIn<'bump, T> for Vec<'bump, T> {
+    fn from_iter_in<I: IntoIterator<Item = T>>(iter: I, bump: &'bump Bump) -> Self {
+        let mut v = Vec::new_in(bump);
+        v.extend(iter);
+        v
     }
 }
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,0 +1,96 @@
+//! Additional `Bump`-related functionality for iterators.
+
+use crate::Bump;
+
+/// `Iterator` extensions for `Bump`-allocated types.
+pub trait BumpIterator: Iterator {
+    /// Transforms an iterator into a `Bump`-allocated collection.
+    fn collect_in<'bump, C>(self, bump: &'bump Bump) -> C
+    where
+        Self: Sized,
+        C: FromIteratorIn<'bump, Self::Item>,
+    {
+        C::from_iter_in(self, bump)
+    }
+}
+
+impl<I: Iterator> BumpIterator for I {}
+
+/// Conversion from an iterator to a `Bump`-allocated type.
+/// This trait is an adapted version of `FromIterator`.
+///
+/// By implementing `FromIteratorIn` for a type, you define how it will be
+/// created from an iterator. This is common for types which describe a
+/// collection of some kind.
+///
+/// `FromIteratorIn`'s `from_iter_in` is rarely called explicitly, and is
+/// instead used through `BumpIterator`'s `collect_in` method.
+pub trait FromIteratorIn<'bump, T> {
+    /// Creates a value from an iterator.
+    /// This method is an adapted version of `FromIterator::from_iter`.
+    fn from_iter_in<I>(iter: I, bump: &'bump Bump) -> Self
+    where
+        I: IntoIterator<Item = T>;
+}
+
+impl<'bump, T, C> FromIteratorIn<'bump, Option<T>> for Option<C>
+where
+    C: FromIteratorIn<'bump, T>,
+{
+    /// Takes each element in the `Iterator`: if it is `None`, no further
+    /// elements are taken, and the `None` is returned. Should no `None` occur,
+    /// a container with the values of each `Option` is returned.
+    fn from_iter_in<I>(iter: I, bump: &'bump Bump) -> Self
+    where
+        I: IntoIterator<Item = Option<T>>,
+    {
+        let mut none = false;
+
+        let c = iter
+            .into_iter()
+            .scan((), |(), option| {
+                if option.is_none() {
+                    none = true;
+                }
+                option
+            })
+            .collect_in(bump);
+
+        if none {
+            None
+        } else {
+            Some(c)
+        }
+    }
+}
+
+impl<'bump, T, E, C> FromIteratorIn<'bump, Result<T, E>> for Result<C, E>
+where
+    C: FromIteratorIn<'bump, T>,
+{
+    /// Takes each element in the `Iterator`: if it is an `Err`, no further
+    /// elements are taken, and the `Err` is returned. Should no `Err` occur, a
+    /// container with the values of each `Result` is returned.
+    fn from_iter_in<I>(iter: I, bump: &'bump Bump) -> Self
+    where
+        I: IntoIterator<Item = Result<T, E>>,
+    {
+        let mut error = None;
+
+        let c = iter
+            .into_iter()
+            .scan((), |(), result| match result {
+                Ok(x) => Some(x),
+                Err(e) => {
+                    error = Some(e);
+                    None
+                }
+            })
+            .collect_in(bump);
+
+        match error {
+            None => Ok(c),
+            Some(e) => Err(e),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,11 +168,11 @@ pub extern crate alloc as core_alloc;
 pub mod boxed;
 #[cfg(feature = "collections")]
 pub mod collections;
+pub mod iter;
 
 mod alloc;
 
 use core::cell::Cell;
-use core::iter;
 use core::marker::PhantomData;
 use core::mem;
 use core::ptr::{self, NonNull};
@@ -1159,7 +1159,7 @@ impl<'a> Iterator for ChunkIter<'a> {
     }
 }
 
-impl<'a> iter::FusedIterator for ChunkIter<'a> {}
+impl<'a> core::iter::FusedIterator for ChunkIter<'a> {}
 
 #[inline(never)]
 #[cold]


### PR DESCRIPTION
Inspired by `Iterator::collect` and `FromIterator`, this adds extension
trait `BumpIterator` with `collect_in`, using a new `FromIteratorIn`
trait for collections to implement.

This unifies the existing inherent `from_iter_in` methods in each
container, and also allows generic tricks like collecting `Result` or
`Option` with short-circuiting.