### PR TITLE
Implement allocator_api

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,13 @@ jobs:
     strategy:
       matrix:
         rust_channel: ["stable", "beta", "nightly", "1.44.0"]
+        feature_set: ["--features collections,boxed"]
+        include:
+          - rust_channel: "nightly"
+            feature_set: "--all-features"
+        exclude:
+          - rust_channel: "nightly"
+            feature_set: "--features collections,boxed"
 
     runs-on: ubuntu-latest
     steps:
@@ -30,8 +37,8 @@ jobs:
 
     - name: Run tests (no features)
       run: cargo test --verbose
-    - name: Run tests (all features)
-      run: cargo test --verbose --all-features
+    - name: Run tests (features)
+      run: cargo test --verbose ${{matrix.feature_set}}
 
   valgrind:
     runs-on: ubuntu-latest
@@ -56,8 +63,8 @@ jobs:
 
     - name: Test under valgrind (no features)
       run: cargo test --verbose
-    - name: Test under valgrind (all features)
-      run: cargo test --verbose --all-features
+    - name: Test under valgrind (features)
+      run: cargo test --verbose --features collections,boxed
 
   benches:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,7 +57,7 @@ jobs:
       run: cargo install cargo-readme --vers "^3"
 
     - name: Install valgrind
-      run: sudo apt install valgrind
+      run: sudo apt update && sudo apt install valgrind
 
     - uses: actions/checkout@v2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ rand = "0.7"
 default = []
 collections = []
 boxed = []
+allocator_api = []
 
 # [profile.bench]
 # debug = true

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Eventually [all `std` collection types will be parameterized by an
 allocator](https://github.com/rust-lang/rust/issues/42774) and we can remove
 this `collections` module and use the `std` versions.
 
+see `allocator_api` support below on nightly.
+
 ### `bumpalo::boxed::Box`
 
 When the `"boxed"` cargo feature is enabled, a fork of `std::boxed::Box` library
@@ -149,6 +151,10 @@ example in `rayon`.
 
 The [`bumpalo-herd`](https://crates.io/crates/bumpalo-herd) crate provides a pool of `Bump`
 allocators for use in such situations.
+
+### `allocator_api` support
+
+Bumpalo provides nightly' `allocator_api` support via the cargo feature `allocator_api`.
 
 #### Minimum Supported Rust Version (MSRV)
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ Eventually [all `std` collection types will be parameterized by an
 allocator](https://github.com/rust-lang/rust/issues/42774) and we can remove
 this `collections` module and use the `std` versions.
 
-see `allocator_api` support below on nightly.
+For unstable, nightly-only support for custom allocators in `std`, see the
+`allocator_api` section below.
 
 ### `bumpalo::boxed::Box`
 
@@ -154,7 +155,33 @@ allocators for use in such situations.
 
 ### `allocator_api` support
 
-Bumpalo provides nightly' `allocator_api` support via the cargo feature `allocator_api`.
+Bumpalo provides nightly' `allocator_api` support via the cargo feature `allocator_api`:
+
+ - Enable support in Cargo.toml:
+```toml
+[dependencies]
+bumpalo = { version = "3.4.0", features = ["allocator_api"] }
+```
+
+ - Enable `allocator_api` in your `src/lib.rs`
+```rust
+#![feature(allocator_api)]
+```
+
+ - Allocator api usage with Bump:
+```rust
+#![feature(allocator_api)]
+use bumpalo::Bump;
+
+// Create a new bump arena.
+let bump = Bump::new();
+
+// Create a `Vec` inside the bump arena.
+let mut c = Vec::new_in(&bump);
+c.push(0);
+c.push(1);
+c.push(2);
+```
 
 #### Minimum Supported Rust Version (MSRV)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1181,6 +1181,63 @@ impl Bump {
             self.current_chunk_footer.get().as_ref().ptr.set(ptr);
         }
     }
+
+    #[inline]
+    unsafe fn shrink(
+        &self,
+        ptr: NonNull<u8>,
+        layout: Layout,
+        new_size: usize,
+    ) -> Result<NonNull<u8>, alloc::AllocErr> {
+        let old_size = layout.size();
+        if self.is_last_allocation(ptr)
+                // Only reclaim the excess space (which requires a copy) if it
+                // is worth it: we are actually going to recover "enough" space
+                // and we can do a non-overlapping copy.
+                && new_size <= old_size / 2
+        {
+            let delta = old_size - new_size;
+            let footer = self.current_chunk_footer.get();
+            let footer = footer.as_ref();
+            footer
+                .ptr
+                .set(NonNull::new_unchecked(footer.ptr.get().as_ptr().add(delta)));
+            let new_ptr = footer.ptr.get();
+            // NB: we know it is non-overlapping because of the size check
+            // in the `if` condition.
+            ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_ptr(), new_size);
+            return Ok(new_ptr);
+        } else {
+            return Ok(ptr);
+        }
+    }
+
+    #[inline]
+    unsafe fn grow(
+        &self,
+        ptr: NonNull<u8>,
+        layout: Layout,
+        new_size: usize,
+    ) -> Result<NonNull<u8>, alloc::AllocErr> {
+        let old_size = layout.size();
+        if self.is_last_allocation(ptr) {
+            // Try to allocate the delta size within this same block so we can
+            // reuse the currently allocated space.
+            let delta = new_size - old_size;
+            if let Some(p) =
+                self.try_alloc_layout_fast(layout_from_size_align(delta, layout.align()))
+            {
+                ptr::copy(ptr.as_ptr(), p.as_ptr(), old_size);
+                return Ok(p);
+            }
+        }
+
+        // Fallback: do a fresh allocation and copy the existing data into it.
+        let new_layout = layout_from_size_align(new_size, layout.align());
+        let new_ptr = self.try_alloc_layout(new_layout)?;
+        ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_ptr(), old_size);
+        Ok(new_ptr)
+    }
 }
 
 /// An iterator over each chunk of allocated memory that
@@ -1251,49 +1308,14 @@ unsafe impl<'a> alloc::Alloc for &'a Bump {
         let old_size = layout.size();
 
         if old_size == 0 {
-            return self.alloc(layout);
+            return self.try_alloc_layout(layout);
         }
 
         if new_size <= old_size {
-            if self.is_last_allocation(ptr)
-                // Only reclaim the excess space (which requires a copy) if it
-                // is worth it: we are actually going to recover "enough" space
-                // and we can do a non-overlapping copy.
-                && new_size <= old_size / 2
-            {
-                let delta = old_size - new_size;
-                let footer = self.current_chunk_footer.get();
-                let footer = footer.as_ref();
-                footer
-                    .ptr
-                    .set(NonNull::new_unchecked(footer.ptr.get().as_ptr().add(delta)));
-                let new_ptr = footer.ptr.get();
-                // NB: we know it is non-overlapping because of the size check
-                // in the `if` condition.
-                ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_ptr(), new_size);
-                return Ok(new_ptr);
-            } else {
-                return Ok(ptr);
-            }
+            self.shrink(ptr, layout, new_size)
+        } else {
+            self.grow(ptr, layout, new_size)
         }
-
-        if self.is_last_allocation(ptr) {
-            // Try to allocate the delta size within this same block so we can
-            // reuse the currently allocated space.
-            let delta = new_size - old_size;
-            if let Some(p) =
-                self.try_alloc_layout_fast(layout_from_size_align(delta, layout.align()))
-            {
-                ptr::copy(ptr.as_ptr(), p.as_ptr(), old_size);
-                return Ok(p);
-            }
-        }
-
-        // Fallback: do a fresh allocation and copy the existing data into it.
-        let new_layout = layout_from_size_align(new_size, layout.align());
-        let new_ptr = self.try_alloc_layout(new_layout)?;
-        ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_ptr(), old_size);
-        Ok(new_ptr)
     }
 }
 
@@ -1307,6 +1329,30 @@ unsafe impl<'a> Allocator for &'a Bump {
 
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
         Bump::dealloc(self, ptr, layout)
+    }
+
+    unsafe fn shrink(
+        &self,
+        ptr: NonNull<u8>,
+        old_layout: Layout,
+        new_layout: Layout,
+    ) -> Result<NonNull<[u8]>, AllocError> {
+        let new_size = new_layout.size();
+        Bump::shrink(self, ptr, old_layout, new_size)
+            .map(|p| NonNull::slice_from_raw_parts(p, new_size))
+            .map_err(|_| AllocError)
+    }
+
+    unsafe fn grow(
+        &self,
+        ptr: NonNull<u8>,
+        old_layout: Layout,
+        new_layout: Layout,
+    ) -> Result<NonNull<[u8]>, AllocError> {
+        let new_size = new_layout.size();
+        Bump::grow(self, ptr, old_layout, new_size)
+            .map(|p| NonNull::slice_from_raw_parts(p, new_size))
+            .map_err(|_| AllocError)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,8 @@ Eventually [all `std` collection types will be parameterized by an
 allocator](https://github.com/rust-lang/rust/issues/42774) and we can remove
 this `collections` module and use the `std` versions.
 
+see `allocator_api` support below on nightly.
+
 ## `bumpalo::boxed::Box`
 
 When the `"boxed"` cargo feature is enabled, a fork of `std::boxed::Box` library
@@ -154,6 +156,10 @@ example in `rayon`.
 
 The [`bumpalo-herd`](https://crates.io/crates/bumpalo-herd) crate provides a pool of `Bump`
 allocators for use in such situations.
+
+## `allocator_api` support
+
+Bumpalo provides nightly' `allocator_api` support via the cargo feature `allocator_api`.
 
 ### Minimum Supported Rust Version (MSRV)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,8 @@ bumpalo = { version = "3.4.0", features = ["allocator_api"] }
 ```
 
  - Allocator api usage with Bump:
-```rust
+```
+# #![cfg_attr(feature = "allocator_api", feature(allocator_api))]
 # #[cfg(feature = "allocator_api")]
 # {
 #![feature(allocator_api)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,8 @@ Eventually [all `std` collection types will be parameterized by an
 allocator](https://github.com/rust-lang/rust/issues/42774) and we can remove
 this `collections` module and use the `std` versions.
 
-see `allocator_api` support below on nightly.
+For unstable, nightly-only support for custom allocators in `std`, see the
+`allocator_api` section below.
 
 ## `bumpalo::boxed::Box`
 
@@ -159,7 +160,39 @@ allocators for use in such situations.
 
 ## `allocator_api` support
 
-Bumpalo provides nightly' `allocator_api` support via the cargo feature `allocator_api`.
+Bumpalo provides nightly' `allocator_api` support via the cargo feature `allocator_api`:
+
+ - Enable support in Cargo.toml:
+```toml
+[dependencies]
+bumpalo = { version = "3.4.0", features = ["allocator_api"] }
+```
+
+ - Enable `allocator_api` in your `src/lib.rs`
+```rust
+# #[cfg(feature = "allocator_api")]
+# {
+#![feature(allocator_api)]
+# }
+```
+
+ - Allocator api usage with Bump:
+```rust
+# #[cfg(feature = "allocator_api")]
+# {
+#![feature(allocator_api)]
+use bumpalo::Bump;
+
+// Create a new bump arena.
+let bump = Bump::new();
+
+// Create a `Vec` inside the bump arena.
+let mut c = Vec::new_in(&bump);
+c.push(0);
+c.push(1);
+c.push(2);
+# }
+```
 
 ### Minimum Supported Rust Version (MSRV)
 

--- a/tests/allocator_api.rs
+++ b/tests/allocator_api.rs
@@ -1,0 +1,12 @@
+#![feature(allocator_api)]
+#![cfg(feature = "allocator_api")]
+use bumpalo::Bump;
+
+#[test]
+fn push_a_bunch_of_items() {
+    let b = Bump::new();
+    let mut v = Vec::new_in(&b);
+    for x in 0..10_000 {
+        v.push(x);
+    }
+}

--- a/tests/allocator_api.rs
+++ b/tests/allocator_api.rs
@@ -2,13 +2,94 @@
 #![cfg(feature = "allocator_api")]
 use bumpalo::Bump;
 
+use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+use std::ptr::NonNull;
+use std::alloc::{Layout, AllocError, Allocator};
+
+#[derive(Debug)]
+struct AllocatorDebug {
+    bump: Bump,
+    grows: AtomicUsize,
+    shrinks: AtomicUsize,
+    allocs: AtomicUsize,
+    deallocs: AtomicUsize,
+}
+
+impl AllocatorDebug {
+    fn new(bump: Bump) -> AllocatorDebug {
+        AllocatorDebug {
+            bump,
+            grows: AtomicUsize::new(0),
+            shrinks: AtomicUsize::new(0),
+            allocs: AtomicUsize::new(0),
+            deallocs: AtomicUsize::new(0),
+        }
+    }
+}
+
+
+
+unsafe impl Allocator for AllocatorDebug {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        self.allocs.fetch_add(1, Relaxed);
+        let ref bump = self.bump;
+        bump.allocate(layout)
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        self.deallocs.fetch_add(1, Relaxed);
+        let ref bump = self.bump;
+        bump.deallocate(ptr, layout)
+    }
+
+    unsafe fn shrink(
+        &self,
+        ptr: NonNull<u8>,
+        old_layout: Layout,
+        new_layout: Layout,
+    ) -> Result<NonNull<[u8]>, AllocError> {
+        self.shrinks.fetch_add(1, Relaxed);
+        let ref bump = self.bump;
+        bump.shrink(ptr, old_layout, new_layout)
+    }
+
+    unsafe fn grow(
+        &self,
+        ptr: NonNull<u8>,
+        old_layout: Layout,
+        new_layout: Layout,
+    ) -> Result<NonNull<[u8]>, AllocError> {
+        self.grows.fetch_add(1, Relaxed);
+        let ref bump = self.bump;
+        bump.grow(ptr, old_layout, new_layout)
+    }
+
+}
+
 #[test]
-fn push_a_bunch_of_items() {
-    let b = Bump::new();
-    let mut v = Vec::new_in(&b);
-    for x in 0..10_000 {
+fn allocator_api_push_a_bunch_of_items() {
+    let b = AllocatorDebug::new(Bump::new());
+    let mut v = Vec::with_capacity_in(1024, &b);
+    assert_eq!(b.allocs.load(Relaxed), 1);
+
+    for x in 0..1024 {
         v.push(x);
     }
 
+    // Ensure we trigger a grow
+    assert_eq!(b.grows.load(Relaxed), 0);
+    for x in 1024..2048 {
+        v.push(x);
+    }
+    assert_ne!(b.grows.load(Relaxed), 0);
+
+    // Ensure we trigger a shrink
+    v.truncate(1024);
+    v.shrink_to_fit();
+    assert_eq!(b.shrinks.load(Relaxed), 1);
+
+    // Ensure we trigger a deallocation
+    assert_eq!(b.deallocs.load(Relaxed), 0);
     drop(v);
+    assert_eq!(b.deallocs.load(Relaxed), 1);
 }

--- a/tests/allocator_api.rs
+++ b/tests/allocator_api.rs
@@ -9,4 +9,6 @@ fn push_a_bunch_of_items() {
     for x in 0..10_000 {
         v.push(x);
     }
+
+    drop(v);
 }


### PR DESCRIPTION
supersedes #68: different approach, collection implementation is kept and this only implements the api needed to satisfy `alloc::alloc::Allocator`
fixes #87 