### PR TITLE
allocator_api: provide a grow_zeroed implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1800,6 +1800,17 @@ unsafe impl<'a> Allocator for &'a Bump {
             .map(|p| NonNull::slice_from_raw_parts(p, new_size))
             .map_err(|_| AllocError)
     }
+
+    unsafe fn grow_zeroed(
+        &self,
+        ptr: NonNull<u8>,
+        old_layout: Layout,
+        new_layout: Layout,
+    ) -> Result<NonNull<[u8]>, AllocError> {
+        let mut ptr = self.grow(ptr, old_layout, new_layout)?;
+        ptr.as_mut()[old_layout.size()..].fill(0);
+        Ok(ptr)
+    }
 }
 
 #[cfg(test)]

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -19,3 +19,17 @@
    fun:syscall
    fun:statx
 }
+{
+   <false positive fixed in valgrind 3.16 and higher part 3>
+   Memcheck:Param
+   statx(buf)
+   fun:statx
+   fun:statx
+}
+{
+   <false positive fixed in valgrind 3.16 and higher part 4>
+   Memcheck:Param
+   statx(file_name)
+   fun:statx
+   fun:statx
+}


### PR DESCRIPTION
Fixup #98

The current implementation of grow_zeroed in liballoc allocates a new chunk, copies data over, then deallocates the old chunk.
Bumpalo can use a more memory efficient version of that, and this is an implementation of it.