### PR TITLE
Fallback when allocating a new chunk fails

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -674,6 +674,8 @@ impl Bump {
                 .unwrap_or_else(allocation_size_overflow);
             let layout = layout_from_size_align(size, align);
 
+            debug_assert!(requested_layout.map_or(true, |layout| size >= layout.size()));
+
             let data = alloc(layout);
             let data = NonNull::new(data)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1444,10 +1444,10 @@ impl Bump {
             let current_footer = self.current_chunk_footer.get();
             let current_layout = current_footer.as_ref().layout;
 
-            // As a sane default, we want our new allocation to be about twice as
-            // big as the previous allocation. If the global allocator refuses it,
-            // we try to divide it by half until it works or the requested size is
-            // smaller than the default footer size.
+            // By default, we want our new chunk to be about twice as big
+            // as the previous chunk. If the global allocator refuses it,
+            // we try to divide it by half until it works or the requested
+            // size is smaller than the default footer size.
             let mut base_size = (current_layout.size() - FOOTER_SIZE).checked_mul(2)?;
             let sizes = iter::from_fn(|| {
                 if base_size >= DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1448,8 +1448,10 @@ impl Bump {
             // as the previous chunk. If the global allocator refuses it,
             // we try to divide it by half until it works or the requested
             // size is smaller than the default footer size.
-            let mut base_size = (current_layout.size() - FOOTER_SIZE).checked_mul(2)?;
             let min_new_chunk_size = layout.size().max(DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER);
+            let mut base_size = (current_layout.size() - FOOTER_SIZE)
+                .checked_mul(2)?
+                .max(min_new_chunk_size);
             let sizes = iter::from_fn(|| {
                 if base_size >= min_new_chunk_size {
                     let size = base_size;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1449,8 +1449,9 @@ impl Bump {
             // we try to divide it by half until it works or the requested
             // size is smaller than the default footer size.
             let mut base_size = (current_layout.size() - FOOTER_SIZE).checked_mul(2)?;
+            let min_new_chunk_size = layout.size().max(DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER);
             let sizes = iter::from_fn(|| {
-                if base_size >= DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER {
+                if base_size >= min_new_chunk_size {
                     let size = base_size;
                     base_size = base_size / 2;
                     Some(size)


### PR DESCRIPTION
When the global allocator is unable to allocate a new chunk, mostly due to the size, the `Bump` struct was either panicking or returning an `AllocErr`. This PR, [discussed in a comment](https://github.com/fitzgen/bumpalo/issues/3#issuecomment-838480426), changes the policy of the `Bump::alloc_layout_slow`:
 1. Try to allocate a chunk twice the size of the last one,
 2. If rejected, try with a chunk of the same size as the last one,
 3. If rejected, try with a chunk of half the size of the last one,
 4. If rejected, continue trying with a size half the previously tried one,
 5. If the size tried is smaller than the default chunk size, return `None` instead of the footer, the same behavior as before.

Trying to allocate half the size of the last chunk helps in allocating the whole available memory, it creates smaller allocations that will more easily fit in the available global memory.