### PR TITLE
Reduce crate size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ name = "bumpalo"
 readme = "./README.md"
 repository = "https://github.com/fitzgen/bumpalo"
 version = "3.7.0"
+include = ["src/**/*", "LICENSE-*", "README.*", "CHANGELOG.md"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "bumpalo"
 readme = "./README.md"
 repository = "https://github.com/fitzgen/bumpalo"
 version = "3.7.0"
-include = ["src/**/*", "LICENSE-*", "README.*", "CHANGELOG.md"]
+exclude = ["/.github/*", "/benches", "/tests", "valgrind.supp", "bumpalo.png"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Using the `include` field in the `Cargo.toml` 23% (or 100.9 KB) can be saved in 18 files (of 433.6 KB and 33 files in entire crate).
The final `.crate` file goes from 131KB to 76.5 KB.