### PR TITLE
Run the `cargo-readme` check as its own CI job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,9 +30,6 @@ jobs:
     - name: Install rust channel
       run: rustup install ${{matrix.rust_channel}} && rustup default ${{matrix.rust_channel}}
 
-    - name: Install `cargo readme`
-      run: cargo install cargo-readme --vers "^3"
-
     - uses: actions/checkout@v2
 
     - name: Run tests (no features)
@@ -52,9 +49,6 @@ jobs:
       run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal
     - name: Install rust stable
       run: rustup install stable && rustup default stable
-
-    - name: Install `cargo readme`
-      run: cargo install cargo-readme --vers "^3"
 
     - name: Install valgrind
       run: sudo apt update && sudo apt install valgrind
@@ -79,3 +73,19 @@ jobs:
 
     - name: Check that benches build
       run: cargo check --benches --all-features
+
+  cargo_readme_up_to_date:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install rustup
+      run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal
+    - name: Install rust channel
+      run: rustup install stable && rustup default stable
+    - name: Install `cargo readme`
+      run: cargo install cargo-readme --vers "^3"
+    - uses: actions/checkout@v2
+    - name: Run `cargo readme`
+      run: cargo readme > README.md
+    - name: Check if up to date; run `cargo readme > README.md` and commit if this fails
+      run: git diff --quiet

--- a/tests/readme_up_to_date.rs
+++ b/tests/readme_up_to_date.rs
@@ -1,22 +1,60 @@
 use std::fs;
+use std::io::Write;
 use std::process::Command;
 
 #[test]
 fn cargo_readme_up_to_date() {
     println!("Checking that `cargo readme > README.md` is up to date...");
 
-    let expected = Command::new("cargo")
+    let child = match Command::new("cargo-readme")
         .arg("readme")
         .current_dir(env!("CARGO_MANIFEST_DIR"))
-        .output()
-        .expect("should run `cargo readme` OK")
-        .stdout;
-    let expected = String::from_utf8_lossy(&expected);
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            warn(e);
+            return;
+        }
+    };
 
+    let output = match child.wait_with_output() {
+        Ok(o) => o,
+        Err(e) => {
+            warn(e);
+            return;
+        }
+    };
+
+    if !output.status.success() {
+        warn(format!(
+            "exited with non-success code {}",
+            output.status.code().unwrap_or(i32::MAX)
+        ));
+        return;
+    }
+
+    let expected = String::from_utf8_lossy(&output.stdout);
     let actual = fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))
         .expect("should read README.md OK");
 
-    if actual != expected {
+    if actual.trim() != expected.trim() {
         panic!("Run `cargo readme > README.md` to update README.md");
+    }
+    return;
+
+    fn warn(e: impl std::fmt::Display) {
+        let stderr = std::io::stderr();
+        let mut stderr = stderr.lock();
+        let _ = writeln!(
+            &mut stderr,
+            "================================================================================\n\
+             WARNING: spawning `cargo-readme` failed; is it installed?\n\
+             `cargo-readme` error: {}\n\
+             Skipping `cargo-readme` check.\n\
+             ================================================================================",
+            e
+        );
     }
 }


### PR DESCRIPTION
And make running it as part of `cargo test` optional so that tests can pass when
`cargo-readme` is not installed.

This should fix CI.