### PR TITLE
Add CollectIn, FromIteratorIn traits to allow for easier construction

### DIFF
--- a/src/collections/collect_in.rs
+++ b/src/collections/collect_in.rs
@@ -1,0 +1,54 @@
+use super::{Vec, String};
+use crate::Bump;
+
+/// Wrapper trait for types that support being constructed from an iterator, parameterized by an allocator.
+pub trait FromIteratorIn<A> {
+    /// An allocator type
+    type Alloc;
+    /// Similar to `from_iter`, but with a given allocator.
+    fn from_iter_in<I>(iter: I, alloc: Self::Alloc) -> Self
+    where I: IntoIterator<Item = A>;
+}
+
+impl<'a, T> FromIteratorIn<T> for Vec<'a, T> {
+    type Alloc = &'a Bump;
+    fn from_iter_in<I>(iter: I, alloc: Self::Alloc) -> Self
+    where I: IntoIterator<Item = T> {
+        Vec::from_iter_in(iter, alloc)
+    }
+}
+
+impl<'a> FromIteratorIn<char> for String<'a> {
+    type Alloc = &'a Bump;
+    fn from_iter_in<I>(iter:I, alloc: Self::Alloc) -> Self
+    where I: IntoIterator<Item = char> {
+        String::from_iter_in(iter, alloc)
+    }
+}
+
+/// Extension trait for iterators, in order to allow allocator-parameterized collections to be constructed more easily.
+pub trait CollectIn: Iterator + Sized {
+
+  /// Collect all items from an iterator, into a collection parameterized by an allocator.
+  /// Similar to `Iterator::collect::<C>()`.
+  ///
+  /// ```rust
+  /// #[cfg(feature = "collections")]
+  /// # use bumpalo::collections::{FromIteratorIn, CollectIn, Vec, String};
+  /// # use bumpalo::Bump;
+  ///
+  /// let bump = Bump::new();
+  ///
+  /// let str = "hello, world!".to_owned();
+  /// let bump_str: String = str.chars().collect_in(&bump);
+  /// assert_eq!(&bump_str, &str);
+  ///
+  /// let nums: Vec<i32> = (0..=3).collect_in::<Vec<_>>(&bump);
+  /// assert_eq!(&nums, &[0,1,2,3]);
+  /// ```
+    fn collect_in<C: FromIteratorIn<Self::Item>>(self, alloc: C::Alloc) -> C {
+        C::from_iter_in(self, alloc)
+    }
+}
+
+impl<I: Iterator> CollectIn for I {}

--- a/src/collections/mod.rs
+++ b/src/collections/mod.rs
@@ -21,6 +21,9 @@ mod str;
 pub mod string;
 pub use self::string::String;
 
+mod collect_in;
+pub use collect_in::{CollectIn, FromIteratorIn};
+
 // pub mod binary_heap;
 // mod btree;
 // pub mod linked_list;

--- a/tests/collect_in.rs
+++ b/tests/collect_in.rs
@@ -1,0 +1,29 @@
+#![cfg(feature = "collections")]
+use bumpalo::collections::{CollectIn,Vec, String};
+use bumpalo::Bump;
+use quickcheck::{quickcheck};
+use std::string::String as StdString;
+use std::vec::Vec as StdVec;
+
+
+#[cfg(test)]
+quickcheck! {
+  fn test_string_collect(input: StdString) -> bool {
+    let bump = Bump::new();
+    let bump_str = input.chars().collect_in::<String>(&bump);
+    &bump_str == &input
+  }
+}
+
+#[cfg(test)]
+quickcheck! {
+  fn test_vec_collect(input: StdVec<i32>) -> bool {
+    let bump = Bump::new();
+    let bump_vec = input.clone().into_iter().collect_in::<Vec<_>>(&bump);
+    let bump_ref: &[i32] = &bump_vec;
+
+    bump_ref == &input
+  }
+
+
+}


### PR DESCRIPTION
Currently, building `Bump`-parameterized collections from iterators is a little verbose, e.g.

```rust
use Bumpalo{Bump, collections::Vec};
let bump = Bump::new();
let xs =  Vec::from_iter_in((0..10), &bump);
```
while a normal `Vec` can be constructed directly using `.collect()`. 

This PR adds 2 new traits, `FromIteratorIn`, and an extension trait `CollectIn` that allows for simpler constructor of bump-parameterized structures. Currently, `Vec` and `String` implement `FromIteratorIn`, and future collections should try to do the same if possible.

On iterators, `CollectIn` allows a more chainable syntax for constructing these collections:

```rust
let bump = Bump::new();
let xs = (0..10).collect_in::<Vec<i32>>(&bump);
```

Quickcheck-based tests are also included and passing. 