### PR TITLE
Fix alloc_slice_fill_zero on architectures where "max alignment" is only 4 (such as i386)

### DIFF
--- a/tests/alloc_fill.rs
+++ b/tests/alloc_fill.rs
@@ -19,7 +19,7 @@ fn alloc_slice_fill_zero() {
     b.alloc_slice_fill_clone(0, &"hello".to_string());
     b.alloc_slice_fill_default::<String>(0);
     let ptr2 = b.alloc(MyZeroSizedType);
-    let alignment = cmp::max(mem::align_of::<u64>(),mem::align_of::<String>());
+    let alignment = cmp::max(mem::align_of::<u64>(), mem::align_of::<String>());
     assert_eq!(ptr1.as_ptr() as usize & !(alignment - 1), ptr2 as *mut _ as usize);
 
     let ptr3 = b.alloc_layout(layout);

--- a/tests/alloc_fill.rs
+++ b/tests/alloc_fill.rs
@@ -1,5 +1,7 @@
 use bumpalo::Bump;
 use std::alloc::Layout;
+use std::mem;
+use std::cmp;
 
 #[test]
 fn alloc_slice_fill_zero() {
@@ -17,7 +19,8 @@ fn alloc_slice_fill_zero() {
     b.alloc_slice_fill_clone(0, &"hello".to_string());
     b.alloc_slice_fill_default::<String>(0);
     let ptr2 = b.alloc(MyZeroSizedType);
-    assert_eq!(ptr1.as_ptr() as usize & !7, ptr2 as *mut _ as usize);
+    let alignment = cmp::max(mem::align_of::<u64>(),mem::align_of::<String>());
+    assert_eq!(ptr1.as_ptr() as usize & !(alignment - 1), ptr2 as *mut _ as usize);
 
     let ptr3 = b.alloc_layout(layout);
     assert_eq!(ptr2 as *mut _ as usize, ptr3.as_ptr() as usize + 1);


### PR DESCRIPTION
The code in alloc_slice_fill_zero assumes that at least one out of u64 and String will have an alignment of 8. However that is not the case on all platforms in particular it is not the case on i386. On i386 the maximum alignment for regular types (I think some SSE stuff is an exception) is 4.

This PR replaces the fixed value 7 with a figure calculated from the actual alignment requirements of String and u64.