### PR TITLE
Replace `array_impls!` macros by const generics

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        rust_channel: ["stable", "beta", "nightly", "1.44.0"]
+        rust_channel: ["stable", "beta", "nightly", "1.51.0"]
         feature_set: ["--features collections,boxed"]
         include:
           - rust_channel: "nightly"

--- a/README.md
+++ b/README.md
@@ -197,9 +197,8 @@ v.push(2);
 
 #### Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.44 and up. It might compile
+This crate is guaranteed to compile on stable Rust 1.51 and up. It might compile
 with older versions but that may change in any new patch release.
 
 We reserve the right to increment the MSRV on minor releases, however we will strive
 to only do it deliberately and for good reasons.
-

--- a/src/collections/vec.rs
+++ b/src/collections/vec.rs
@@ -1983,26 +1983,23 @@ __impl_slice_eq1! { Vec<'a, A>, &'b [B] }
 __impl_slice_eq1! { Vec<'a, A>, &'b mut [B] }
 // __impl_slice_eq1! { Cow<'a, [A]>, Vec<'b, B>, Clone }
 
-macro_rules! array_impls {
-    ($($N: expr)+) => {
-        $(
-            // NOTE: some less important impls are omitted to reduce code bloat
-            __impl_slice_eq1! { Vec<'a, A>, [B; $N] }
-            __impl_slice_eq1! { Vec<'a, A>, &'b [B; $N] }
-            // __impl_slice_eq1! { Vec<A>, &'b mut [B; $N] }
-            // __impl_slice_eq1! { Cow<'a, [A]>, [B; $N], Clone }
-            // __impl_slice_eq1! { Cow<'a, [A]>, &'b [B; $N], Clone }
-            // __impl_slice_eq1! { Cow<'a, [A]>, &'b mut [B; $N], Clone }
-        )+
-    }
+macro_rules! __impl_slice_eq1_array {
+    ($Lhs: ty, $Rhs: ty) => {
+        impl<'a, 'b, A, B, const N: usize> PartialEq<$Rhs> for $Lhs
+        where
+            A: PartialEq<B>,
+        {
+            #[inline]
+            fn eq(&self, other: &$Rhs) -> bool {
+                self[..] == other[..]
+            }
+        }
+    };
 }
 
-array_impls! {
-     0  1  2  3  4  5  6  7  8  9
-    10 11 12 13 14 15 16 17 18 19
-    20 21 22 23 24 25 26 27 28 29
-    30 31 32
-}
+__impl_slice_eq1_array! { Vec<'a, A>, [B; N] }
+__impl_slice_eq1_array! { Vec<'a, A>, &'b [B; N] }
+__impl_slice_eq1_array! { Vec<'a, A>, &'b mut [B; N] }
 
 /// Implements comparison of vectors, lexicographically.
 impl<'bump, T: 'bump + PartialOrd> PartialOrd for Vec<'bump, T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,12 +209,11 @@ v.push(2);
 
 ### Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.44 and up. It might compile
+This crate is guaranteed to compile on stable Rust 1.51 and up. It might compile
 with older versions but that may change in any new patch release.
 
 We reserve the right to increment the MSRV on minor releases, however we will strive
 to only do it deliberately and for good reasons.
-
  */
 
 #![deny(missing_debug_implementations)]
@@ -420,7 +419,7 @@ impl<E: Display> Display for AllocOrInitError<E> {
 ///
 /// Even when optimizations are on, these functions do not **guarantee** that
 /// the value is constructed on the heap. To the best of our knowledge no such
-/// guarantee can be made in stable Rust as of 1.44.
+/// guarantee can be made in stable Rust as of 1.51.
 ///
 /// ### Fallible Initialization: The `_try_with` Method Suffix
 ///


### PR DESCRIPTION
Resolves #131. I bumped the MSRV to 1.51, since that's when const generics were stabilized, but I can also directly bump it to 1.54 (which is required for #123).