### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
CI broke, since you apparently renamed `master` to `main` (I wondered why it didn't run on [my PR](https://github.com/fitzgen/bumpalo/pull/140)). I also took the liberty to rename `rust.yml` to `rust.yaml`, as `.yaml` is the [officially recommended file extension](https://yaml.org/faq.html).