### PR TITLE
Account for alignment changes when growing or shrinking

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,6 +321,13 @@ pub(crate) fn round_up_to(n: usize, divisor: usize) -> Option<usize> {
     Some(n.checked_add(divisor - 1)? & !(divisor - 1))
 }
 
+#[inline]
+pub(crate) fn round_down_to(n: usize, divisor: usize) -> usize {
+    debug_assert!(divisor > 0);
+    debug_assert!(divisor.is_power_of_two());
+    n & !(divisor - 1)
+}
+
 // After this point, we try to hit page boundaries instead of powers of 2
 const PAGE_STRATEGY_CUTOFF: usize = 0x1000;
 
@@ -1493,7 +1500,7 @@ impl Bump {
 
         // This is how much space we would *actually* reclaim while satisfying
         // the requested alignment.
-        let delta = (old_size - new_size) & !(new_layout.align() - 1);
+        let delta = round_down_to(old_size - new_size, new_layout.align());
 
         if self.is_last_allocation(ptr)
                 // Only reclaim the excess space (which requires a copy) if it

--- a/tests/allocator_api.rs
+++ b/tests/allocator_api.rs
@@ -1,6 +1,7 @@
-#![feature(allocator_api, slice_ptr_get)]
+#![feature(allocator_api)]
 #![cfg(feature = "allocator_api")]
 use bumpalo::Bump;
+use quickcheck::quickcheck;
 
 use std::alloc::{AllocError, Allocator, Layout};
 use std::ptr::NonNull;
@@ -115,17 +116,100 @@ fn allocator_grow_zeroed() {
     assert_eq!(unsafe { p.as_ref() }, [42, 42, 42, 42, 0, 0, 0, 0]);
 }
 
-#[test]
-fn allocator_grow_layout_change() {
-    let b = AllocatorDebug::new(Bump::with_capacity(1024));
+quickcheck! {
+    fn allocator_grow_align_increase(layouts: Vec<(usize, usize)>) -> bool {
+        let mut layouts: Vec<_> = layouts.into_iter().map(|(size, align)| {
+            const MIN_SIZE: usize = 1;
+            const MAX_SIZE: usize = 1024;
+            const MIN_ALIGN: usize = 1;
+            const MAX_ALIGN: usize = 64;
 
-    let layout_align4 = Layout::from_size_align(256, 4).unwrap();
-    let layout_align16 = Layout::from_size_align(1024, 16).unwrap();
+            let align = usize::min(usize::max(align, MIN_ALIGN), MAX_ALIGN);
+            let align = usize::next_power_of_two(align);
 
-    // Allocate a chunk of memory and attempt to grow it while increasing
-    // alignment requirements.
-    let p4 = b.allocate(layout_align4).unwrap().as_non_null_ptr();
-    let _p16 = unsafe { b.grow(p4, layout_align4, layout_align16).unwrap() };
+            let size = usize::min(usize::max(size, MIN_SIZE), MAX_SIZE);
+            let size = usize::max(size, align);
+
+            Layout::from_size_align(size, align).unwrap()
+        }).collect();
+
+        layouts.sort_unstable_by_key(|l| (l.size(), l.align()));
+
+        let b = AllocatorDebug::new(Bump::new());
+        let mut layout_iter = layouts.into_iter();
+
+        if let Some(initial_layout) = layout_iter.next() {
+            let mut pointer = b.allocate(initial_layout).unwrap();
+            if !is_pointer_aligned_to(pointer, initial_layout.align()) {
+                return false;
+            }
+
+            let mut old_layout = initial_layout;
+
+            for new_layout in layout_iter {
+                pointer = unsafe { b.grow(pointer.cast(), old_layout, new_layout).unwrap() };
+                if !is_pointer_aligned_to(pointer, new_layout.align()) {
+                    return false;
+                }
+
+                old_layout = new_layout;
+            }
+        }
+
+        true
+    }
+}
+
+quickcheck! {
+    fn allocator_shrink_align_change(layouts: Vec<(usize, usize)>) -> bool {
+        let mut layouts: Vec<_> = layouts.into_iter().map(|(size, align)| {
+            const MIN_SIZE: usize = 1;
+            const MAX_SIZE: usize = 1024;
+            const MIN_ALIGN: usize = 1;
+            const MAX_ALIGN: usize = 64;
+
+            let align = usize::min(usize::max(align, MIN_ALIGN), MAX_ALIGN);
+            let align = usize::next_power_of_two(align);
+
+            let size = usize::min(usize::max(size, MIN_SIZE), MAX_SIZE);
+            let size = usize::max(size, align);
+
+            Layout::from_size_align(size, align).unwrap()
+        }).collect();
+
+        layouts.sort_unstable_by_key(|l| l.size());
+        layouts.reverse();
+
+        let b = AllocatorDebug::new(Bump::new());
+        let mut layout_iter = layouts.into_iter();
+
+        if let Some(initial_layout) = layout_iter.next() {
+            let mut pointer = b.allocate(initial_layout).unwrap();
+            if !is_pointer_aligned_to(pointer, initial_layout.align()) {
+                return false;
+            }
+
+            let mut old_layout = initial_layout;
+
+            for new_layout in layout_iter {
+                let res = unsafe { b.shrink(pointer.cast(), old_layout, new_layout) };
+                if old_layout.align() < new_layout.align() {
+                    if res.is_ok() {
+                        return false;
+                    }
+                } else {
+                    pointer = res.unwrap();
+                    if !is_pointer_aligned_to(pointer, new_layout.align()) {
+                        return false;
+                    }
+
+                    old_layout = new_layout;
+                }
+            }
+        }
+
+        true
+    }
 }
 
 #[test]
@@ -137,8 +221,17 @@ fn allocator_shrink_layout_change() {
 
     // Allocate a chunk of memory and attempt to shrink it while increasing
     // alignment requirements.
-    let p4 = b.allocate(layout_align4).unwrap().as_non_null_ptr();
+    let p4: NonNull<u8> = b.allocate(layout_align4).unwrap().cast();
     let p16_res = unsafe { b.shrink(p4, layout_align4, layout_align16) };
 
     assert_eq!(p16_res, Err(AllocError));
+}
+
+fn is_pointer_aligned_to(p: NonNull<[u8]>, align: usize) -> bool {
+    debug_assert!(align.is_power_of_two());
+
+    let pointer = p.as_ptr() as *mut u8 as usize;
+    let pointer_aligned = pointer & !(align - 1);
+
+    pointer == pointer_aligned
 }


### PR DESCRIPTION
My riff on #143

Both `Bump::grow` and `Bump::shrink` now take in the new layout and check for alignment compatibility. `Bump::grow` falls back to `Bump::try_alloc_layout` if the alignment is not compatible, and `Bump::shrink` just returns `AllocError` in this case.

These above strategies are pretty much up to us. The Allocator trait says it is ok to error out, if it can't handle the new requirements. For bump allocation, I'd personally prefer shrinking to fail instead of allocating, if the alignment requirements changed.

Afaik, the collections in alloc don't change alignment during their life (unless transmuted), and while I can imagine legitimate code that would want to do this, the same code would probably write their own allocator.

Also added two tests, but `allocator_grow_layout_change` doesn't really test anything just yet. It is a bit tricky to figure out when grow falls back to `Bump::try_alloc_layout` without instrumenting Bump itself with counters. Ideas?