### PR TITLE
Remove ptr-int-ptr casts

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -37,6 +37,23 @@ jobs:
     - name: Run tests (features)
       run: cargo test --verbose ${{matrix.feature_set}}
 
+  miri:
+    runs-on: ubuntu-latest
+
+    env:
+      MIRIFLAGS: "-Zmiri-tag-raw-pointers -Zmiri-check-number-validity -Zmiri-ignore-leaks"
+
+    steps:
+    - name: Install rustup
+      run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly -y
+    - name: Install miri
+      run: rustup toolchain install nightly --allow-downgrade --profile minimal --component miri
+
+    - uses: actions/checkout@v2
+
+    - name: Run miri
+      run: cargo miri test
+
   valgrind:
     runs-on: ubuntu-latest
 

--- a/tests/quickchecks.rs
+++ b/tests/quickchecks.rs
@@ -1,3 +1,7 @@
+// Miri is very slow. Even with QUICKCHECK_MAX_TESTS=1 the tests in this module run for more than
+// an hour.
+#![cfg(not(miri))]
+
 use bumpalo::Bump;
 use quickcheck::{quickcheck, Arbitrary, Gen};
 use std::mem;


### PR DESCRIPTION
This replaces ptr-int-ptr roundtrips as well as ptr-int casts which were
used to produce usize values to do arithmetic on instead of doing
pointer arithmetic operations on pointers to u8. These ptr-int-ptr
roundtrips are a thorny case for aliasing models to deal with, and thus
play havoc with unsafe checkers such as Miri, and complicate alias
analysis and aliasing models. Removing them does not necessarily remove
UB, but it significantly simplifies the semantics of this code and makes
it easier to rule out definite forms of UB.