### PR TITLE
Fix Vec::push in Miri tests with -Zmiri-tag-raw-pointers

### DIFF
--- a/src/collections/vec.rs
+++ b/src/collections/vec.rs
@@ -1296,7 +1296,7 @@ impl<'bump, T: 'bump> Vec<'bump, T> {
             self.reserve(1);
         }
         unsafe {
-            let end = self.as_mut_ptr().add(self.len);
+            let end = self.buf.ptr().add(self.len);
             ptr::write(end, value);
             self.len += 1;
         }


### PR DESCRIPTION
This avoids going through the slice deref, fixing a Miri error. It might be worth porting over the current `std::vec` implementation, as the current one seems to be old and the error doesn't occur in `std::vec` anymore. But this is just a quick band-aid fix for this particular error.