### PR TITLE
cargo fmt

### DIFF
--- a/src/collections/collect_in.rs
+++ b/src/collections/collect_in.rs
@@ -57,7 +57,10 @@ impl<T, V: FromIteratorIn<T>> FromIteratorIn<Option<T>> for Option<V> {
     where
         I: IntoIterator<Item = Option<T>>,
     {
-        iter.into_iter().map(|x| x.ok_or(())).collect_in::<Result<_, _>>(alloc).ok()
+        iter.into_iter()
+            .map(|x| x.ok_or(()))
+            .collect_in::<Result<_, _>>(alloc)
+            .ok()
     }
 }
 
@@ -93,16 +96,15 @@ impl<T, E, V: FromIteratorIn<T>> FromIteratorIn<Result<T, E>> for Result<V, E> {
     {
         let mut iter = iter.into_iter();
         let mut error = None;
-        let container = core::iter::from_fn(|| {
-            match iter.next() {
-                Some(Ok(x)) => Some(x),
-                Some(Err(e)) => {
-                    error = Some(e);
-                    None
-                }
-                None => None,
+        let container = core::iter::from_fn(|| match iter.next() {
+            Some(Ok(x)) => Some(x),
+            Some(Err(e)) => {
+                error = Some(e);
+                None
             }
-        }).collect_in(alloc);
+            None => None,
+        })
+        .collect_in(alloc);
 
         match error {
             Some(e) => Err(e),

--- a/tests/alloc_fill.rs
+++ b/tests/alloc_fill.rs
@@ -1,7 +1,7 @@
 use bumpalo::Bump;
 use std::alloc::Layout;
-use std::mem;
 use std::cmp;
+use std::mem;
 
 #[test]
 fn alloc_slice_fill_zero() {
@@ -20,7 +20,10 @@ fn alloc_slice_fill_zero() {
     b.alloc_slice_fill_default::<String>(0);
     let ptr2 = b.alloc(MyZeroSizedType);
     let alignment = cmp::max(mem::align_of::<u64>(), mem::align_of::<String>());
-    assert_eq!(ptr1.as_ptr() as usize & !(alignment - 1), ptr2 as *mut _ as usize);
+    assert_eq!(
+        ptr1.as_ptr() as usize & !(alignment - 1),
+        ptr2 as *mut _ as usize
+    );
 
     let ptr3 = b.alloc_layout(layout);
     assert_eq!(ptr2 as *mut _ as usize, ptr3.as_ptr() as usize + 1);


### PR DESCRIPTION
To avoid reverting half of the diff when invoking `cargo fmt` in
other PRs.