### PR TITLE
Do not allocate empty chunk

### DIFF
--- a/tests/try_alloc.rs
+++ b/tests/try_alloc.rs
@@ -124,7 +124,7 @@ fn main() {
     let tests = [
         test!("Bump::try_new fails when global allocator fails", || {
             GLOBAL_ALLOCATOR.with_alloc_failures(|| {
-                assert!(Bump::try_new().is_err());
+                assert!(Bump::try_with_capacity(1).is_err());
             });
         }),
         test!(


### PR DESCRIPTION
`Bump::new` should not allocate. This is useful when we need quick
temporary storage and we don't know if we need to allocate or not.