### PR TITLE
Add support for allocation limits on arenas

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -99,7 +99,7 @@ fn size_align<T>() -> (usize, usize) {
 }
 
 /// The `AllocErr` error indicates an allocation failure
-/// that may be due to resource exhaustion, reaching an allocation limit, or
+/// that may be due to resource exhaustion or to
 /// something wrong when combining the given input arguments with this
 /// allocator.
 // #[unstable(feature = "allocator_api", issue = "32838")]

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -99,7 +99,7 @@ fn size_align<T>() -> (usize, usize) {
 }
 
 /// The `AllocErr` error indicates an allocation failure
-/// that may be due to resource exhaustion or to
+/// that may be due to resource exhaustion, reaching an allocation limit, or
 /// something wrong when combining the given input arguments with this
 /// allocator.
 // #[unstable(feature = "allocator_api", issue = "32838")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -476,6 +476,12 @@ fn allocation_size_overflow<T>() -> T {
     panic!("requested allocation size overflowed")
 }
 
+// This can be migrated to directly use `usize::abs_diff` when the MSRV
+// reaches `1.60`
+fn abs_diff(a: usize, b: usize) -> usize {
+    usize::max(a, b) - usize::min(a, b)
+}
+
 impl Bump {
     /// Construct a new arena to bump allocate into.
     ///
@@ -594,7 +600,7 @@ impl Bump {
             if allocated_bytes > allocation_limit {
                 None
             } else {
-                Some(allocation_limit.abs_diff(allocated_bytes))
+                Some(abs_diff(allocation_limit, allocated_bytes))
             }
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,6 +452,8 @@ const FIRST_ALLOCATION_GOAL: usize = 1 << 9;
 // take the alignment into account.
 const DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER: usize = FIRST_ALLOCATION_GOAL - OVERHEAD;
 
+/// The memory size and alignment details for a potential new chunk
+/// allocation.
 #[derive(Debug, Clone, Copy)]
 struct NewChunkMemoryDetails {
     new_size_without_footer: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,8 +255,8 @@ impl<E: Display> Display for AllocOrInitError<E> {
 ///
 /// ### `Bump` Allocation Limits
 ///
-/// `Bump` supports setting a limit on the maximum bytes of memory that can
-/// be allocated for use. This limit can be set and removed with
+/// `bumpalo` supports setting a limit on the maximum bytes of memory that can
+/// be allocated for use in a particular `Bump` arena. This limit can be set and removed with
 /// [`set_allocation_limit`][Bump::set_allocation_limit] and
 /// [`remove_allocation_limit`][Bump::remove_allocation_limit].
 /// Changing the limit for a `Bump` while it has live allocations does

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,9 +258,9 @@ impl<E: Display> Display for AllocOrInitError<E> {
 /// `bumpalo` supports setting a limit on the maximum bytes of memory that can
 /// be allocated for use in a particular `Bump` arena. This limit can be set and removed with
 /// [`set_allocation_limit`][Bump::set_allocation_limit].
-/// Changing the limit for a `Bump` while it has live allocations does
-/// nothing until a new allocation is attempted, at which point it may fail
-/// due to the new limit.
+/// The allocation limit is only enforced when allocating new backing chunks for
+/// a `Bump`. Updating the allocation limit will not affect existing allocations
+/// or any future allocations within the `Bump`'s current chunk.
 ///
 /// ## Example
 ///
@@ -557,9 +557,9 @@ impl Bump {
 
     /// Set the allocation limit in bytes for this arena.
     ///
-    /// Changing the limit for a `Bump` while it has live allocations does
-    /// nothing until a new allocation is attempted, at which point it may fail
-    /// due to the new limit.
+    /// The allocation limit is only enforced when allocating new backing chunks for
+    /// a `Bump`. Updating the allocation limit will not affect existing allocations
+    /// or any future allocations within the `Bump`'s current chunk.
     ///
     /// ## Example
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -587,17 +587,14 @@ impl Bump {
     /// How much headroom an arena has before it hits its allocation
     /// limit.
     fn allocation_limit_remaining(&self) -> Option<usize> {
-        self.allocation_limit
-            .get()
-            .map(|allocation_limit| {
-                let allocated_bytes = self.allocated_bytes();
-                if allocated_bytes > allocation_limit {
-                    None
-                } else {
-                    Some(allocation_limit.abs_diff(allocated_bytes))
-                }
-            })
-            .unwrap_or(None)
+        self.allocation_limit.get().and_then(|allocation_limit| {
+            let allocated_bytes = self.allocated_bytes();
+            if allocated_bytes > allocation_limit {
+                None
+            } else {
+                Some(allocation_limit.abs_diff(allocated_bytes))
+            }
+        })
     }
 
     /// Whether a request to allocate a new chunk with a given size for a given

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -567,7 +567,6 @@ impl Bump {
 
     /// How much headroom an arena has before it hits its allocation
     /// limit.
-    #[inline(always)]
     fn allocation_limit_remaining(&self) -> Option<usize> {
         self.allocation_limit
             .get()
@@ -583,7 +582,6 @@ impl Bump {
     }
 
     /// Whether a new allocation fits within the headroom before the allocation limit.
-    #[inline(always)]
     fn new_allocation_fits_under_limit(
         allocation_limit_remaining: Option<usize>,
         allocation_size: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1500,7 +1500,7 @@ impl Bump {
                 if base_size >= min_new_chunk_size || bypass_min_chunk_size_for_small_limits {
                     let size = base_size;
                     base_size = base_size / 2;
-                    Some(Bump::new_chunk_memory_details(Some(size), layout)).flatten()
+                    Bump::new_chunk_memory_details(Some(size), layout)
                 } else {
                     None
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,8 +257,7 @@ impl<E: Display> Display for AllocOrInitError<E> {
 ///
 /// `bumpalo` supports setting a limit on the maximum bytes of memory that can
 /// be allocated for use in a particular `Bump` arena. This limit can be set and removed with
-/// [`set_allocation_limit`][Bump::set_allocation_limit] and
-/// [`remove_allocation_limit`][Bump::remove_allocation_limit].
+/// [`set_allocation_limit`][Bump::set_allocation_limit].
 /// Changing the limit for a `Bump` while it has live allocations does
 /// nothing until a new allocation is attempted, at which point it may fail
 /// due to the new limit.
@@ -269,15 +268,15 @@ impl<E: Display> Display for AllocOrInitError<E> {
 /// let bump = bumpalo::Bump::new();
 ///
 /// assert_eq!(bump.allocation_limit(), None);
-/// bump.set_allocation_limit(0);
+/// bump.set_allocation_limit(Some(0));
 ///
 /// assert!(bump.try_alloc(5).is_err());
 ///
-/// bump.set_allocation_limit(6);
+/// bump.set_allocation_limit(Some(6));
 ///
 /// assert_eq!(bump.allocation_limit(), Some(6));
 ///
-/// bump.remove_allocation_limit();
+/// bump.set_allocation_limit(None);
 ///
 /// assert_eq!(bump.allocation_limit(), None);
 /// ```
@@ -535,11 +534,11 @@ impl Bump {
     ///
     /// assert_eq!(bump.allocation_limit(), None);
     ///
-    /// bump.set_allocation_limit(6);
+    /// bump.set_allocation_limit(Some(6));
     ///
     /// assert_eq!(bump.allocation_limit(), Some(6));
     ///
-    /// bump.remove_allocation_limit();
+    /// bump.set_allocation_limit(None);
     ///
     /// assert_eq!(bump.allocation_limit(), None);
     /// ```
@@ -558,31 +557,12 @@ impl Bump {
     /// ```
     /// let bump = bumpalo::Bump::with_capacity(0);
     ///
-    /// bump.set_allocation_limit(0);
+    /// bump.set_allocation_limit(Some(0));
     ///
     /// assert!(bump.try_alloc(5).is_err());
     /// ```
-    pub fn set_allocation_limit(&self, new_limit: usize) {
-        self.allocation_limit.set(Some(new_limit))
-    }
-
-    /// Remove the allocation limit in bytes for this arena.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// let bump = bumpalo::Bump::with_capacity(0);
-    ///
-    /// bump.set_allocation_limit(0);
-    ///
-    /// assert!(bump.try_alloc(5).is_err());
-    ///
-    /// bump.remove_allocation_limit();
-    ///
-    /// assert!(bump.try_alloc(5).is_ok());
-    /// ```
-    pub fn remove_allocation_limit(&self) {
-        self.allocation_limit.set(None)
+    pub fn set_allocation_limit(&self, limit: Option<usize>) {
+        self.allocation_limit.set(limit)
     }
 
     /// How much headroom an arena has before it hits its allocation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,7 +262,7 @@ impl<E: Display> Display for AllocOrInitError<E> {
 /// a `Bump`. Updating the allocation limit will not affect existing allocations
 /// or any future allocations within the `Bump`'s current chunk.
 ///
-/// ## Example
+/// #### Example
 ///
 /// ```
 /// let bump = bumpalo::Bump::new();

--- a/tests/allocation_limit.rs
+++ b/tests/allocation_limit.rs
@@ -1,0 +1,80 @@
+use std::alloc::Layout;
+
+use bumpalo::Bump;
+use quickcheck::quickcheck;
+
+#[test]
+fn allocation_limit_trivial() {
+    let bump = Bump::with_capacity(0);
+    bump.set_allocation_limit(0);
+
+    assert!(bump.try_alloc(5).is_err());
+    assert!(bump.allocation_limit().unwrap() >= bump.allocated_bytes());
+
+    bump.remove_allocation_limit();
+
+    assert!(bump.try_alloc(5).is_ok());
+}
+
+#[test]
+fn change_allocation_limit_with_live_allocations() {
+    let bump = Bump::new();
+
+    bump.set_allocation_limit(512);
+
+    bump.alloc(10);
+
+    assert!(bump.try_alloc([0; 2048]).is_err());
+
+    bump.set_allocation_limit(16384);
+
+    assert!(bump.try_alloc([0; 2048]).is_ok());
+    assert!(bump.allocation_limit().unwrap() >= bump.allocated_bytes());
+}
+
+#[test]
+fn remove_allocation_limit_with_live_allocations() {
+    let bump = Bump::new();
+
+    bump.set_allocation_limit(512);
+
+    bump.alloc(10);
+
+    assert!(bump.try_alloc([0; 2048]).is_err());
+    assert!(bump.allocation_limit().unwrap() >= bump.allocated_bytes());
+
+    bump.remove_allocation_limit();
+
+    assert!(bump.try_alloc([0; 2048]).is_ok());
+}
+
+#[test]
+fn reset_preserves_allocation_limits() {
+    let mut bump = Bump::new();
+
+    bump.set_allocation_limit(512);
+    bump.reset();
+
+    assert!(bump.try_alloc([0; 2048]).is_err());
+    assert!(bump.allocation_limit().unwrap() >= bump.allocated_bytes());
+}
+
+quickcheck! {
+    fn limit_is_never_exceeded(xs: usize) -> bool {
+        let b = Bump::new();
+
+        b.set_allocation_limit(xs);
+
+        // The exact numbers here on how much to allocate are a bit murky but we
+        // have two main goals.
+        //
+        // - Attempt to allocate over the allocation limit imposed
+        // - Allocate in increments small enough that at least a few allocations succeed
+        let layout = Layout::array::<u8>(xs / 16).unwrap();
+        for _ in 0..32 {
+            let _ = b.try_alloc_layout(layout);
+        }
+
+        b.allocation_limit().unwrap() >= b.allocated_bytes()
+    }
+}

--- a/tests/allocation_limit.rs
+++ b/tests/allocation_limit.rs
@@ -59,6 +59,32 @@ fn reset_preserves_allocation_limits() {
     assert!(bump.allocation_limit().unwrap() >= bump.allocated_bytes());
 }
 
+#[test]
+fn reset_updates_allocated_bytes() {
+    let mut bump = Bump::new();
+
+    bump.alloc([0; 1 << 9]);
+
+    // This second allocation should be a big enough one
+    // after the first to force a new chunk allocation
+    bump.alloc([0; 1 << 9]);
+
+    let allocated_bytes_before_reset = bump.allocated_bytes();
+
+    bump.reset();
+
+    let allocated_bytes_after_reset = bump.allocated_bytes();
+
+    assert!(allocated_bytes_after_reset < allocated_bytes_before_reset);
+}
+
+#[test]
+fn new_bump_allocated_bytes_is_zero() {
+    let bump = Bump::new();
+
+    assert_eq!(bump.allocated_bytes(), 0);
+}
+
 quickcheck! {
     fn limit_is_never_exceeded(xs: usize) -> bool {
         let b = Bump::new();

--- a/tests/allocation_limit.rs
+++ b/tests/allocation_limit.rs
@@ -86,10 +86,6 @@ fn new_bump_allocated_bytes_is_zero() {
 fn small_allocation_limit() {
     let bump = Bump::new();
 
-    // 64 is chosen because any limit below 64 is
-    // unreasonably tight when trying to optimize the
-    // allocation and will always fail due to our attempts
-    // to allocate chunks in 'nice' sizes
     bump.set_allocation_limit(Some(64));
     assert!(bump.try_alloc([0; 1]).is_ok());
 }

--- a/tests/allocation_limit.rs
+++ b/tests/allocation_limit.rs
@@ -86,21 +86,21 @@ fn new_bump_allocated_bytes_is_zero() {
 }
 
 quickcheck! {
-    fn limit_is_never_exceeded(xs: usize) -> bool {
+    fn limit_is_never_exceeded(limit: usize) -> bool {
         let b = Bump::new();
 
-        b.set_allocation_limit(Some(xs));
+        b.set_allocation_limit(Some(limit));
 
         // The exact numbers here on how much to allocate are a bit murky but we
         // have two main goals.
         //
         // - Attempt to allocate over the allocation limit imposed
         // - Allocate in increments small enough that at least a few allocations succeed
-        let layout = Layout::array::<u8>(xs / 16).unwrap();
+        let layout = Layout::array::<u8>(limit / 16).unwrap();
         for _ in 0..32 {
             let _ = b.try_alloc_layout(layout);
         }
 
-        b.allocation_limit().unwrap() >= b.allocated_bytes()
+        limit >= b.allocated_bytes()
     }
 }


### PR DESCRIPTION
Implements #135 

Arenas can optionally keep track of an `allocation_limit` which is
considered when allocating new chunks to an arena.

The limit is only checked in `alloc_layout_slow` and `new_chunk`, which means it
should have a low performance overhead as the limit is only checked when trying to hit
the global allocator.

To further avoid performance concerns, `ChunkFooter` has been refactored to keep
track of the total allocated bytes, allowing `Bump::allocated_bytes` to avoid
performing a walk of the chunk list.

No new `new` methods were added, and limits must be set after the
creation of a `Bump` arena. Limits can be changed on the fly and are
only enforced when attempting to allocate new chunks.

No changes were made to the errors returned by operations like `alloc`
because of backwards compatibility.

I'm new to open source contributions and library development so sorry if there's anything obvious I missed.