### PR TITLE
Enable `boxed` feature in miri CI

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -54,7 +54,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Run miri
-      run: cargo miri test
+      run: cargo miri test --features boxed
 
   valgrind:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Not enabling the `collections` feature because of #164.