### PR TITLE
Fix oom_instead_of_bump_pointer_overflow breakage

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -71,7 +71,7 @@ fn oom_instead_of_bump_pointer_overflow() {
     let p = x as *mut u8 as usize;
 
     // A size guaranteed to overflow the bump pointer.
-    let size = usize::MAX - p + 1;
+    let size = (isize::MAX as usize) - p + 1;
     let align = 1;
     let layout = match Layout::from_size_align(size, align) {
         Err(e) => {


### PR DESCRIPTION
Nightly changes tp the `Layout` API have caused this test to break as
layouts are now restricted to a max size of `isize::MAX`. This is fixed
by using `isize::MAX` instead of `usize::MAX` in the test.

This test has been a bit controversial in the past but some of the problems
with it have been dealt with up to the present, like not allocating enough to
guarantee an OOM error.

Fixes #174 