### PR TITLE
allocated_bytes_with_headers function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1696,6 +1696,16 @@ impl Bump {
         unsafe { footer.as_ref().allocated_bytes }
     }
 
+    /// Calculates the number of bytes requested from the Rust allocator for this `Bump`.
+    ///
+    /// This number is equal to the [`allocated_bytes()`](Self::allocated_bytes) plus
+    /// the size of the bump metadata.
+    pub fn allocated_bytes_including_metadata(&self) -> usize {
+        let metadata_size =
+            unsafe { self.iter_allocated_chunks_raw().count() * mem::size_of::<ChunkFooter>() };
+        self.allocated_bytes() + metadata_size
+    }
+
     #[inline]
     unsafe fn is_last_allocation(&self, ptr: NonNull<u8>) -> bool {
         let footer = self.current_chunk_footer.get();

--- a/tests/all/quickchecks.rs
+++ b/tests/all/quickchecks.rs
@@ -284,4 +284,26 @@ quickcheck! {
 
         bump.allocated_bytes() <= limit
     }
+
+    fn allocated_bytes_including_metadata(allocs: Vec<usize>) -> () {
+        let b = Bump::new();
+        let mut slice_bytes = 0;
+        let allocs_len = allocs.len();
+        for len in allocs {
+            const MAX_LEN: usize = 512;
+            let len = len % MAX_LEN;
+            b.alloc_slice_fill_copy(len, 0);
+            slice_bytes += len;
+            let allocated_bytes = b.allocated_bytes();
+            let allocated_bytes_including_metadata = b.allocated_bytes_including_metadata();
+            if slice_bytes == 0 {
+                assert_eq!(allocated_bytes, 0);
+                assert_eq!(allocated_bytes_including_metadata, 0);
+            } else {
+                assert!(allocated_bytes >= slice_bytes);
+                assert!(allocated_bytes_including_metadata > allocated_bytes);
+                assert!(allocated_bytes_including_metadata < allocated_bytes + allocs_len * 100);
+            }
+        }
+    }
 }


### PR DESCRIPTION
We are implementing memory profiler, and for such profiler we need to know allocation overhead as precise as possible (especially for small bumps where header size overhead might be significant).

`allocated_bytes` function does not include header size.

So add `allocated_bytes_with_headers` which returns the amount of memory requested from rust allocator.