### PR TITLE
Add Vec::bump method

### DIFF
--- a/src/collections/vec.rs
+++ b/src/collections/vec.rs
@@ -675,6 +675,26 @@ impl<'bump, T: 'bump> Vec<'bump, T> {
         }
     }
 
+    /// Returns a shared reference to the allocator backing this `Vec`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bumpalo::{Bump, collections::Vec};
+    ///
+    /// // uses the same allocator as the provided `Vec`
+    /// fn add_strings<'bump>(vec: &mut Vec<'bump, &'bump str>) {
+    ///     for string in ["foo", "bar", "baz"] {
+    ///         vec.push(vec.bump().alloc_str(string));
+    ///     }
+    /// }
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn bump(&self) -> &'bump Bump {
+        self.buf.bump()
+    }
+
     /// Returns the number of elements the vector can hold without
     /// reallocating.
     ///


### PR DESCRIPTION
This PR adds a way to get the `Bump` allocator backing a `Vec`, for example to make more allocations if the `Vec` contains other bump-allocated data structures.

One common example of this is a bump-allocated recursive data structure. Consider:

```rust
use bumpalo::Bump;
use bumpalo::collections::Vec;

struct Tree<'bump> {
	value: i32,
	children: Vec<'bump, Self>,
}

impl Tree<'bump> {
	fn new(value: i32, bump: &'bump Bump) -> Self {
		Self {
			value,
			children: Vec::new_in(bump),
		}
	}

	fn add_child(&mut self, value: i32) {
		self.children.push(Self::new(value, self.children.bump()));
	}
}
```

Without this PR, `Recursive` would be forced to carry an extra shared reference to the `Bump`.
