### PR TITLE
Update actions/checkout in GitHub Actions workflows to v3

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -32,7 +32,7 @@ jobs:
     - name: Install rust channel
       run: rustup install ${{matrix.rust_channel}} && rustup default ${{matrix.rust_channel}}
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Run tests (no features)
       run: cargo test --verbose
@@ -51,7 +51,7 @@ jobs:
     - name: Install miri
       run: rustup toolchain install nightly --allow-downgrade --profile minimal --component miri
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Run miri
       run: cargo miri test --all-features
@@ -72,7 +72,7 @@ jobs:
     - name: Install valgrind
       run: sudo apt update && sudo apt install valgrind
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Test under valgrind (no features)
       run: cargo test --verbose
@@ -88,7 +88,7 @@ jobs:
     - name: Install rust nightly
       run: rustup install nightly && rustup default nightly
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Check that benches build
       run: cargo check --benches --all-features


### PR DESCRIPTION
Updates the `actions/checkout` action used in the GitHub Actions workflows to its newest major version.

Changes in [actions/checkout](https://github.com/actions/checkout):

> ## v3.3.0
> - Implement branch list using callbacks from exec function
> - Add in explicit reference to private checkout options
> - Fix comment typos
>
> ## v3.2.0
> - Add GitHub Action to perform release
> - Fix status badge
> - Replace datadog/squid with ubuntu/squid Docker image
> - Wrap pipeline commands for submoduleForeach in quotes
> - Update @actions/io to 1.1.2
> - Upgrading version to 3.2.0
>
> ## v3.1.0
> - Use @actions/core `saveState` and `getState`
> - Add `github-server-url` input
>
> ## v3.0.2
> - Add input `set-safe-directory`
>
> ## v3.0.1
> - Fixed an issue where checkout failed to run in container jobs due to the new git setting `safe.directory`
> - Bumped various npm package versions
>
> ## v3.0.0
>
> - Update to node 16

Still using v2 of `actions/checkout` will generate some warning like in this run: https://github.com/fitzgen/bumpalo/actions/runs/4116939118

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings for `actions/checkout`, because v3 uses Node.js 16.