### PR TITLE
Add `#[inline]` annotations to all public functions

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -109,6 +109,7 @@ pub struct AllocErr;
 // (we need this for downstream impl of trait Error)
 // #[unstable(feature = "allocator_api", issue = "32838")]
 impl fmt::Display for AllocErr {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str("memory allocation failed")
     }


### PR DESCRIPTION
Functions which are not marked `#[inline]` cannot be inlined when called from third-party crates without LTO enabled. This PR adds `#[inline]` annotations to public functions which were missing them, and adds a clippy warning to ensure future public functions are always marked `#[inline]`