### PR TITLE
Use allocator-api through allocator-api2 crate

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        rust_channel: ["stable", "beta", "nightly", "1.60.0"]
+        rust_channel: ["stable", "beta", "nightly", "1.63.0"]
         feature_set: ["--features collections,boxed"]
         include:
           - rust_channel: "nightly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,17 @@
 
 Released YYYY-MM-DD.
 
-### Added
-
-* TODO (or remove section if none)
-
 ### Changed
 
-* The minimum supported Rust version (MSRV) is now 1.60.0.
-* TODO (or remove section if none)
+* The minimum supported Rust version (MSRV) is now 1.63.0.
+* `"allocator_api"` feature now uses either unstable API from `std` or 
+  `allocator-api2` crate - a mirror of the unstable API usable on stable.
+
+### Added
+
+* New `"nightly"` feature enables use of unstable API and requires nightly channel.
+  Enabling `allocator_api` nightly Rust feature is required
+  when using `"nightly"` feature
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,19 @@
 
 Released YYYY-MM-DD.
 
+### Added
+
+* New `"allocator-api2"` feature enables use of allocator API on stable.
+  This feature uses a crate that mirrors the API of
+  unstable `allocator_api` feature.
+  If feature is enabled, references to `Bump` implement
+  `allocator_api2::Allocator`.
+  This allows `Bump` to be used as allocator for collection types from
+  `allocator-api2` and any other crates that support `allocator-api2`.
+
 ### Changed
 
 * The minimum supported Rust version (MSRV) is now 1.63.0.
-* `"allocator_api"` feature now uses either unstable API from `std` or 
-  `allocator-api2` crate - a mirror of the unstable API usable on stable.
-
-### Added
-
-* New `"nightly"` feature enables use of unstable API and requires nightly channel.
-  Enabling `allocator_api` nightly Rust feature is required
-  when using `"nightly"` feature
 
 ### Deprecated
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ path = "tests/try_alloc.rs"
 harness = false
 
 [dependencies]
-allocator-api2 = { version = "0.2.7-rc.1", default-features = false, optional = true, features = ["alloc"] }
+allocator-api2 = { version = "0.2.8", default-features = false, optional = true, features = ["alloc"] }
 
 [dev-dependencies]
 quickcheck = "1.0.3"
@@ -42,8 +42,7 @@ rand = "0.8.5"
 default = []
 collections = []
 boxed = []
-allocator_api = ["allocator-api2"]
-nightly = ["allocator_api"]
+allocator_api = []
 
 # [profile.bench]
 # debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ name = "try_alloc"
 path = "tests/try_alloc.rs"
 harness = false
 
+[dependencies]
+allocator-api2 = { version = "0.2.6" }
+
 [dev-dependencies]
 quickcheck = "1.0.3"
 criterion = "0.3.6"
@@ -39,7 +42,7 @@ rand = "0.8.5"
 default = []
 collections = []
 boxed = []
-allocator_api = []
+allocator_api = ["allocator-api2/nightly"]
 
 # [profile.bench]
 # debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ path = "tests/try_alloc.rs"
 harness = false
 
 [dependencies]
-allocator-api2 = { version = "0.2.6", default-features = false, features = ["alloc"] }
+allocator-api2 = { version = "0.2.7-rc.1", default-features = false, optional = true, features = ["alloc"] }
 
 [dev-dependencies]
 quickcheck = "1.0.3"
@@ -42,7 +42,8 @@ rand = "0.8.5"
 default = []
 collections = []
 boxed = []
-allocator_api = ["allocator-api2/nightly"]
+allocator_api = ["allocator-api2"]
+nightly = ["allocator_api"]
 
 # [profile.bench]
 # debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ path = "tests/try_alloc.rs"
 harness = false
 
 [dependencies]
-allocator-api2 = { version = "0.2.6" }
+allocator-api2 = { version = "0.2.6", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ v.push(2);
 
 #### Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust **1.60** and up. It might
+This crate is guaranteed to compile on stable Rust **1.63** and up. It might
 compile with older versions but that may change in any new patch release.
 
 We reserve the right to increment the MSRV on minor releases, however we will

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![no_std]
-#![cfg_attr(feature = "nightly", feature(allocator_api))]
+#![cfg_attr(feature = "allocator_api", feature(allocator_api))]
 
 #[doc(hidden)]
 pub extern crate alloc as core_alloc;
@@ -24,10 +24,10 @@ use core::slice;
 use core::str;
 use core_alloc::alloc::{alloc, dealloc, Layout};
 
-#[cfg(feature = "nightly")]
+#[cfg(feature = "allocator_api")]
 use core_alloc::alloc::{AllocError, Allocator};
 
-#[cfg(all(feature = "allocator_api", not(feature = "nightly")))]
+#[cfg(all(feature = "allocator-api2", not(feature = "allocator_api")))]
 use allocator_api2::alloc::{AllocError, Allocator};
 
 pub use alloc::AllocErr;
@@ -1887,7 +1887,7 @@ unsafe impl<'a> alloc::Alloc for &'a Bump {
     }
 }
 
-#[cfg(feature = "allocator_api")]
+#[cfg(any(feature = "allocator_api", feature = "allocator-api2"))]
 unsafe impl<'a> Allocator for &'a Bump {
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
         self.try_alloc_layout(layout)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,7 @@
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![no_std]
-#![cfg_attr(
-    feature = "allocator_api",
-    feature(allocator_api, nonnull_slice_from_raw_parts)
-)]
+#![cfg_attr(feature = "allocator_api", feature(allocator_api))]
 
 #[doc(hidden)]
 pub extern crate alloc as core_alloc;
@@ -25,9 +22,8 @@ use core::mem;
 use core::ptr::{self, NonNull};
 use core::slice;
 use core::str;
-use core_alloc::alloc::{alloc, dealloc, Layout};
-#[cfg(feature = "allocator_api")]
-use core_alloc::alloc::{AllocError, Allocator};
+
+use allocator_api2::alloc::{alloc, dealloc, AllocError, Allocator, Layout};
 
 pub use alloc::AllocErr;
 
@@ -1886,11 +1882,12 @@ unsafe impl<'a> alloc::Alloc for &'a Bump {
     }
 }
 
-#[cfg(feature = "allocator_api")]
 unsafe impl<'a> Allocator for &'a Bump {
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
         self.try_alloc_layout(layout)
-            .map(|p| NonNull::slice_from_raw_parts(p, layout.size()))
+            .map(|p| unsafe {
+                NonNull::new_unchecked(ptr::slice_from_raw_parts_mut(p.as_ptr(), layout.size()))
+            })
             .map_err(|_| AllocError)
     }
 
@@ -1905,7 +1902,9 @@ unsafe impl<'a> Allocator for &'a Bump {
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
         Bump::shrink(self, ptr, old_layout, new_layout)
-            .map(|p| NonNull::slice_from_raw_parts(p, new_layout.size()))
+            .map(|p| unsafe {
+                NonNull::new_unchecked(ptr::slice_from_raw_parts_mut(p.as_ptr(), new_layout.size()))
+            })
             .map_err(|_| AllocError)
     }
 
@@ -1916,7 +1915,9 @@ unsafe impl<'a> Allocator for &'a Bump {
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
         Bump::grow(self, ptr, old_layout, new_layout)
-            .map(|p| NonNull::slice_from_raw_parts(p, new_layout.size()))
+            .map(|p| unsafe {
+                NonNull::new_unchecked(ptr::slice_from_raw_parts_mut(p.as_ptr(), new_layout.size()))
+            })
             .map_err(|_| AllocError)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![no_std]
-#![cfg_attr(feature = "allocator_api", feature(allocator_api))]
+#![cfg_attr(feature = "nightly", feature(allocator_api))]
 
 #[doc(hidden)]
 pub extern crate alloc as core_alloc;
@@ -22,8 +22,13 @@ use core::mem;
 use core::ptr::{self, NonNull};
 use core::slice;
 use core::str;
+use core_alloc::alloc::{alloc, dealloc, Layout};
 
-use allocator_api2::alloc::{alloc, dealloc, AllocError, Allocator, Layout};
+#[cfg(feature = "nightly")]
+use core_alloc::alloc::{AllocError, Allocator};
+
+#[cfg(all(feature = "allocator_api", not(feature = "nightly")))]
+use allocator_api2::alloc::{AllocError, Allocator};
 
 pub use alloc::AllocErr;
 
@@ -1882,6 +1887,7 @@ unsafe impl<'a> alloc::Alloc for &'a Bump {
     }
 }
 
+#[cfg(feature = "allocator_api")]
 unsafe impl<'a> Allocator for &'a Bump {
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
         self.try_alloc_layout(layout)


### PR DESCRIPTION
This change allows to use mirror of the allocator-api on stable channel.
Types imported from `allocator-api2` are reexports from `core` and `alloc` crates when `"nightly"` feature is enabled.
Otherwise `allocator-api2` defines types to mimic unstable `core` and `alloc` types and functions, stable stuff is re-exported.

The goal is to add support for `allocator-api2` into as many crates as possible.
The `bumpalo` crate is first on the list.