### PR TITLE
Remove `unsafe` from `EmptyChunkFooter::get()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,7 +354,7 @@ static EMPTY_CHUNK: EmptyChunkFooter = EmptyChunkFooter(ChunkFooter {
 
 impl EmptyChunkFooter {
     fn get(&'static self) -> NonNull<ChunkFooter> {
-        unsafe { NonNull::new_unchecked(&self.0 as *const ChunkFooter as *mut ChunkFooter) }
+        NonNull::from(&self.0)
     }
 }
 


### PR DESCRIPTION
Have I completely misunderstood this or can we really get rid of an `unsafe` block this easily?