### PR TITLE
Add `Bump::alloc_str_concat`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1269,6 +1269,10 @@ impl Bump {
         let mut bytes = iter.flat_map(|s| s.as_ref().bytes());
         let buffer = self.alloc_slice_fill_with(total_len, |_| bytes.next().unwrap());
 
+        // This assert is necessary to guard against misbehaving `Iterator` implementations leading
+        // to invalid UTF-8 in strings.
+        assert_eq!(bytes.next(), None);
+
         unsafe {
             // This is OK, because it already came in as str, so it is guaranteed to be utf8
             str::from_utf8_unchecked_mut(buffer)

--- a/tests/all/quickchecks.rs
+++ b/tests/all/quickchecks.rs
@@ -236,6 +236,14 @@ quickcheck! {
         }
     }
 
+    fn alloc_str_concats(allocs: Vec<Vec<String>>) -> () {
+        let b = Bump::new();
+        let allocated: Vec<&str> = allocs.iter().map(|s| b.alloc_str_concat(s) as &_).collect();
+        for (val, alloc) in allocs.into_iter().zip(allocated) {
+            assert_eq!(val.concat(), alloc);
+        }
+    }
+
     fn all_allocations_in_a_chunk(values: Vec<BigValue>) -> () {
         let b = Bump::new();
         let allocated: Vec<&BigValue> = values.into_iter().map(|val| b.alloc(val) as &_).collect();


### PR DESCRIPTION
I thought this would be a useful function to have. The motivation behind the `&impl AsRef<str>` design is that it greatly simplifies the implementation in comparison to `impl AsRef<str>` (see the previous commit) — also, as the iterator is iterated twice users should be producing references anyway.