### PR TITLE
Avoid constructing layouts with larger than `isize::MAX` sizes

### DIFF
--- a/tests/all/capacity.rs
+++ b/tests/all/capacity.rs
@@ -1,0 +1,7 @@
+use bumpalo::Bump;
+
+#[test]
+fn try_with_capacity_too_large() {
+    // Shouldn't panic even though the capacity is too large for a `Layout`.
+    let _ = Bump::try_with_capacity(isize::MAX as usize + 1);
+}

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -5,6 +5,8 @@ mod alloc_try_with;
 mod alloc_with;
 mod allocation_limit;
 mod allocator_api;
+mod boxed;
+mod capacity;
 mod collect_in;
 mod quickcheck;
 mod quickchecks;
@@ -13,6 +15,5 @@ mod tests;
 mod try_alloc_try_with;
 mod try_alloc_with;
 mod vec;
-mod boxed;
 
 fn main() {}


### PR DESCRIPTION
Fixes #200