### PR TITLE
Fix chunk_capacity to return the remaining capacity, not the total

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1455,7 +1455,7 @@ impl Bump {
         let current_footer = self.current_chunk_footer.get();
         let current_footer = unsafe { current_footer.as_ref() };
 
-        current_footer as *const _ as usize - current_footer.data.as_ptr() as usize
+        current_footer.ptr.get().as_ptr() as usize - current_footer.data.as_ptr() as usize
     }
 
     /// Slow path allocation for when we need to allocate a new chunk from the

--- a/tests/all/tests.rs
+++ b/tests/all/tests.rs
@@ -201,3 +201,11 @@ fn test_alignment() {
         }
     }
 }
+
+#[test]
+fn test_chunk_capacity() {
+    let b = Bump::with_capacity(512);
+    let orig_capacity = b.chunk_capacity();
+    b.alloc(true);
+    assert!(b.chunk_capacity() < orig_capacity);
+}


### PR DESCRIPTION
`chunk_capacity` is documented as returning "the remaining capacity in the current chunk", but actually returns the *total* capacity for the current chunk.

(Arguably, the actual behavior is itself totally sensible, and this is a documentation bug, though in that case I would propose adding a new function that returns the remaining capacity. I would like it for debugging/measurement purposes.)