### PR TITLE
Implement `std::io::Write` for `Vec<'bump, u8>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ default = []
 collections = []
 boxed = []
 allocator_api = []
+std = []
 
 # [profile.bench]
 # debug = true

--- a/README.md
+++ b/README.md
@@ -155,7 +155,14 @@ in its space itself.
 
 ### `#![no_std]` Support
 
-Bumpalo is a `no_std` crate. It depends only on the `alloc` and `core` crates.
+Bumpalo is a `no_std` crate by default. It depends only on the `alloc` and `core` crates.
+
+### `std` Support
+
+You can optionally decide to enable the `std` feature in order to enable some
+std only trait implementations for some collections:
+
+* `std::io::Write` for `Vec<'bump, u8>`
 
 ### Thread support
 

--- a/src/collections/vec.rs
+++ b/src/collections/vec.rs
@@ -104,6 +104,8 @@ use core::ops::{Index, IndexMut, RangeBounds};
 use core::ptr;
 use core::ptr::NonNull;
 use core::slice;
+#[cfg(feature = "std")]
+use std::io;
 
 unsafe fn arith_offset<T>(p: *const T, offset: isize) -> *const T {
     p.offset(offset)
@@ -2610,5 +2612,25 @@ where
         unsafe {
             self.vec.set_len(self.old_len - self.del);
         }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'bump> io::Write for Vec<'bump, u8> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.extend_from_slice(buf);
+        Ok(())
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "allocator_api", feature(allocator_api))]
 
 #[doc(hidden)]

--- a/tests/all/vec.rs
+++ b/tests/all/vec.rs
@@ -105,3 +105,30 @@ fn test_vec_items_get_dropped() {
     }
     assert_eq!("Dropped!Dropped!", buffer.borrow().deref());
 }
+
+#[cfg(feature = "std")]
+#[test]
+fn test_vec_write() {
+    use std::io::Write;
+
+    let b = Bump::new();
+    let mut v = bumpalo::vec![in &b];
+
+    assert_eq!(v.write(&[]).unwrap(), 0);
+
+    v.flush().unwrap();
+
+    assert_eq!(v.write(&[1]).unwrap(), 1);
+
+    v.flush().unwrap();
+
+    v.write_all(&[]).unwrap();
+
+    v.flush().unwrap();
+
+    v.write_all(&[2, 3]).unwrap();
+
+    v.flush().unwrap();
+
+    assert_eq!(v, &[1, 2, 3]);
+}


### PR DESCRIPTION
Hi @fitzgen 

Here is my attempt to implement `std::io::Write` for `Vec<'bump, u8>`
I believe there are other common traits like this we could implement for some collections but I have left that for another time (but I 'd be happy to contribute those).

I have a few questions:
1. The current `std` feature does not do anything on its own, it's currently only useful if you also have the `collections` feature enabled too. I think it's fine but I wondered if having instead a `collections-std` feature depending on `collections` would be better? Although the `std` feature is pretty standard across the community.
2. Are there enough tests and are they at the right place? The implementation seems trivial and has been copied from std (except for the vectored part that is currently unstable).

Fixes https://github.com/fitzgen/bumpalo/issues/215