### PR TITLE
fixed `_` instead of `-` in name `allocator-api2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,8 +216,8 @@ v.push(2);
 
 ### Using the `Allocator` API on Stable Rust
 
-You can enable the `allocator_api2` Cargo feature and `bumpalo` will use [the
-`allocator_api2` crate](https://crates.io/crates/allocator-api2) to implement
+You can enable the `allocator-api2` Cargo feature and `bumpalo` will use [the
+`allocator-api2` crate](https://crates.io/crates/allocator-api2) to implement
 the unstable nightly`Allocator` API on stable Rust. This means that
 `bumpalo::Bump` will be usable with any collection that is generic over
 `allocator_api2::Allocator`.


### PR DESCRIPTION
The names of both the referenced crate and the cargo feature are `allocator-api2` and *not* `allocator_api2`.

This change was introduced [here](https://github.com/fitzgen/bumpalo/commit/fd3dd5767658ad634581d0bc8267c3ed00ec9ec5#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R212-R213).