### PR TITLE
clippy: Allow large_enum_variant in tests.

### DIFF
--- a/tests/all/alloc_with.rs
+++ b/tests/all/alloc_with.rs
@@ -53,6 +53,7 @@ fn alloc_with_large_tuple() {
     });
 }
 
+#[allow(clippy::large_enum_variant)]
 enum LargeEnum {
     Small,
     #[allow(dead_code)]

--- a/tests/all/try_alloc_with.rs
+++ b/tests/all/try_alloc_with.rs
@@ -55,6 +55,7 @@ fn try_alloc_with_large_tuple() {
     .unwrap();
 }
 
+#[allow(clippy::large_enum_variant)]
 enum LargeEnum {
     Small,
     #[allow(dead_code)]


### PR DESCRIPTION
2 instances of this enum already had this, but it was missing from these two.