### PR TITLE
Bump MSRV to 1.65.

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        rust_channel: ["stable", "beta", "nightly", "1.63.0"]
+        rust_channel: ["stable", "beta", "nightly", "1.65.0"]
         feature_set: ["--features collections,boxed"]
         include:
           - rust_channel: "nightly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Released YYYY-MM-DD.
 
 ### Changed
 
-* TODO (or remove section if none)
+* The minimum supported Rust version (MSRV) is now 1.63.0.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Released YYYY-MM-DD.
 
 ### Changed
 
-* The minimum supported Rust version (MSRV) is now 1.63.0.
+* The minimum supported Rust version (MSRV) is now 1.65.0.
 
 ### Deprecated
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 repository = "https://github.com/fitzgen/bumpalo"
 version = "3.14.0"
 exclude = ["/.github/*", "/benches", "/tests", "valgrind.supp", "bumpalo.png"]
-rust-version = "1.60.0"
+rust-version = "1.65.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ the unstable nightly`Allocator` API on stable Rust. This means that
 
 ### Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust **1.63** and up. It might
+This crate is guaranteed to compile on stable Rust **1.65** and up. It might
 compile with older versions but that may change in any new patch release.
 
 We reserve the right to increment the MSRV on minor releases, however we will


### PR DESCRIPTION
Currently, the regex crate requires this, but it will also allow to bump the criterion crate.