### PR TITLE
Pinned Box 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ harness = false
 # trait on stable Rust. Enabling this feature means that `bumpalo` will
 # implement its `Allocator` trait.
 allocator-api2 = { version = "0.2.8", default-features = false, optional = true }
+memoffset = { version = "0.9.0", optional = true }
 
 [dev-dependencies]
 quickcheck = "1.0.3"
@@ -45,6 +46,7 @@ rand = "0.8.5"
 default = []
 collections = []
 boxed = []
+pin = ["dep:memoffset"]
 allocator_api = []
 std = []
 

--- a/src/drop.rs
+++ b/src/drop.rs
@@ -1,0 +1,110 @@
+use core::{
+    cell::{Cell, UnsafeCell},
+    marker::PhantomPinned,
+    mem::MaybeUninit,
+    ptr::NonNull,
+};
+
+/// A circular doubly linked list.
+#[derive(Debug, Default)]
+pub struct DropList {
+    pub link: Link,
+}
+
+impl DropList {
+    /// Safety: `self` must be pinned.
+    #[inline]
+    pub unsafe fn init(&self) {
+        let link_ptr = Some(NonNull::from(&self.link));
+        self.link.prev.set(link_ptr);
+        self.link.next.set(link_ptr);
+    }
+
+    pub unsafe fn insert(&self, node: NonNull<Link>) {
+        insert_after(NonNull::from(&self.link), node)
+    }
+
+    pub unsafe fn run_drop(&self) {
+        let mut curr = self.link.next.get().unwrap();
+        let end = NonNull::from(&self.link);
+        while curr != end {
+            let entry = unsafe { curr.cast::<DropEntry<()>>().as_ref() };
+            unsafe {
+                (entry.drop_fn)(entry.data.assume_init_ref().get());
+            }
+            curr = entry.link.next.get().unwrap();
+        }
+    }
+}
+
+#[inline]
+unsafe fn insert_after(tail: NonNull<Link>, node_ptr: NonNull<Link>) {
+    let tail = tail.as_ref();
+
+    let node = node_ptr.as_ref();
+    node.prev.set(Some(NonNull::from(tail)));
+    node.next.set(tail.next.get());
+
+    tail.next.get().unwrap().as_ref().prev.set(Some(node_ptr));
+    tail.next.set(Some(node_ptr));
+}
+
+#[derive(Debug, Default)]
+pub struct Link {
+    prev: Cell<Option<NonNull<Link>>>,
+    next: Cell<Option<NonNull<Link>>>,
+    _marker: PhantomPinned,
+}
+
+impl Link {
+    pub unsafe fn unlink(&self) {
+        let Some(prev) = self.prev.take() else {
+            return;
+        };
+        let next = self.next.take().unwrap();
+        prev.as_ref().next.set(Some(next));
+        next.as_ref().prev.set(Some(prev));
+    }
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct DropEntry<T> {
+    link: Link,
+    drop_fn: unsafe fn(*mut ()),
+    data: MaybeUninit<UnsafeCell<T>>,
+}
+
+impl<T> DropEntry<T> {
+    #[inline]
+    pub fn new(val: T) -> Self {
+        Self {
+            link: Link::default(),
+            drop_fn: unsafe {
+                core::mem::transmute::<_, unsafe fn(*mut ())>(
+                    core::ptr::drop_in_place::<T> as unsafe fn(*mut T),
+                )
+            },
+            data: MaybeUninit::new(UnsafeCell::new(val)),
+        }
+    }
+
+    #[inline]
+    pub unsafe fn link_and_data(&self) -> (NonNull<Link>, *mut T) {
+        (NonNull::from(&self.link), self.data.assume_init_ref().get())
+    }
+
+    #[inline]
+    pub unsafe fn ptr_from_data(data: *mut T) -> NonNull<DropEntry<T>> {
+        NonNull::new_unchecked(
+            data.byte_sub(memoffset::offset_of!(Self, data))
+                .cast::<DropEntry<T>>(),
+        )
+    }
+
+    #[inline]
+    pub unsafe fn link_from_data(data: *mut T) -> NonNull<Link> {
+        let entry = Self::ptr_from_data(data).as_ptr();
+        NonNull::new_unchecked(core::ptr::addr_of_mut!((*entry).link))
+    }
+}

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -8,6 +8,7 @@ mod allocator_api;
 mod boxed;
 mod capacity;
 mod collect_in;
+mod pin;
 mod quickcheck;
 mod quickchecks;
 mod string;

--- a/tests/all/pin.rs
+++ b/tests/all/pin.rs
@@ -1,0 +1,149 @@
+#![cfg(feature = "pin")]
+
+use core::future::Future;
+use std::{
+    mem,
+    pin::Pin,
+    rc::Rc,
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc,
+    },
+    task::{Context, Poll, Wake, Waker},
+};
+
+use bumpalo::pin::Box;
+use bumpalo::Bump;
+
+struct NoopWaker;
+
+impl Wake for NoopWaker {
+    fn wake(self: std::sync::Arc<Self>) {}
+}
+
+#[test]
+fn box_pin() {
+    let bump = Bump::new();
+    let mut fut = Box::pin_in(async { 1 }, &bump);
+    let fut = fut.as_mut();
+
+    let waker = Waker::from(Arc::new(NoopWaker));
+    let mut context = Context::from_waker(&waker);
+
+    assert_eq!(fut.poll(&mut context), Poll::Ready(1));
+}
+
+#[test]
+fn box_pin_drop() {
+    struct Foo(Rc<AtomicBool>);
+    impl Drop for Foo {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    let dropped = Rc::new(AtomicBool::new(false));
+
+    let bump = Bump::new();
+    let foo = Box::pin_in(Foo(dropped.clone()), &bump);
+    drop(foo);
+
+    assert!(dropped.load(Ordering::SeqCst));
+}
+
+#[test]
+fn box_pin_mut_drop() {
+    struct Foo(Rc<AtomicBool>, String);
+    impl Drop for Foo {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    let dropped = Rc::new(AtomicBool::new(false));
+
+    let bump = Bump::new();
+    let mut foo = Box::pin_in(Foo(dropped.clone(), String::new()), &bump);
+    foo.1.push_str("123");
+
+    drop(foo);
+
+    assert!(dropped.load(Ordering::SeqCst));
+}
+
+#[test]
+fn box_pin_forget_drop() {
+    struct Foo(Rc<AtomicBool>);
+    impl Drop for Foo {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    let dropped = Rc::new(AtomicBool::new(false));
+
+    let bump = Bump::new();
+    mem::forget(Box::pin_in(Foo(dropped.clone()), &bump));
+    assert!(!dropped.load(Ordering::SeqCst));
+
+    drop(bump);
+
+    assert!(dropped.load(Ordering::SeqCst));
+}
+
+#[test]
+fn box_pin_multiple_forget_drop() {
+    struct Foo(Rc<AtomicUsize>);
+    impl Drop for Foo {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    let dropped = Rc::new(AtomicUsize::new(0));
+
+    let bump = Bump::new();
+    mem::forget(Box::pin_in(Foo(dropped.clone()), &bump));
+    mem::forget(Box::pin_in(Foo(dropped.clone()), &bump));
+    mem::drop(Box::pin_in(Foo(dropped.clone()), &bump));
+    mem::forget(Box::pin_in(Foo(dropped.clone()), &bump));
+
+    assert_eq!(dropped.load(Ordering::SeqCst), 1);
+
+    drop(bump);
+
+    assert_eq!(dropped.load(Ordering::SeqCst), 4);
+}
+
+#[test]
+fn box_pin_raw() {
+    struct Foo(Rc<AtomicBool>, String);
+    impl Drop for Foo {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    let dropped = Rc::new(AtomicBool::new(false));
+
+    let bump = Bump::new();
+    let foo = Pin::into_inner(Box::pin_in(Foo(dropped.clone(), String::new()), &bump));
+    let ptr = Box::into_raw(foo);
+
+    unsafe { (*ptr).1.push_str("Hello World") };
+
+    let foo = unsafe { Box::from_raw(ptr, &bump) };
+    drop(foo);
+
+    assert!(dropped.load(Ordering::SeqCst));
+}
+
+#[test]
+fn into_raw_aliasing() {
+    let bump = Bump::new();
+    let boxed = Box::new_in(1, &bump);
+    let raw = Box::into_raw(boxed);
+
+    let mut_ref = unsafe { &mut *raw };
+    dbg!(mut_ref);
+}


### PR DESCRIPTION
Fixes https://github.com/fitzgen/bumpalo/issues/226, https://github.com/fitzgen/bumpalo/issues/186.

This adds new "pinned" Box type (`pin::Box<T>`), that guarantees running `T`'s drop impl whenever the box is leaked and the `Bump` allocator is reset or dropped.

The impl utilizes a "intrusive circular doubly linked list" that links every "pinned" allocation that needs a cleanup. Each list entry detaches when the Box itself is dropped.
That way, when the `Bump` allocator is cleared, we can run the `Drop` impls by traversing the list.

The pinned Box is still one pointer-sized big. We can calculate the each allocation's header pointer by doing some pointer arithmetic. Note that this only passes miri with tree-borrows enabled (not compatible with stacked borrows and reports UB) due to the kind of container-of style pointer arithmetic being used. 

# TODO

- Some more cleanups
- Right now the docs are basically copy and pasted and needs to be rewritten
- More testing