### PR TITLE
Improve performance of `String::push_str`

### DIFF
--- a/tests/all/string.rs
+++ b/tests/all/string.rs
@@ -17,3 +17,20 @@ fn trailing_comma_in_format_macro() {
     let v = format![in &b, "{}{}", 1, 2, ];
     assert_eq!(v, "12");
 }
+
+#[test]
+fn push_str() {
+    let b = Bump::new();
+    let mut s = String::new_in(&b);
+    s.push_str("abc");
+    assert_eq!(s, "abc");
+    s.push_str("def");
+    assert_eq!(s, "abcdef");
+    s.push_str("");
+    assert_eq!(s, "abcdef");
+    s.push_str(&"x".repeat(4000));
+    assert_eq!(s.len(), 4006);
+    s.push_str("ghi");
+    assert_eq!(s.len(), 4009);
+    assert_eq!(&s[s.len() - 5..], "xxghi");
+}


### PR DESCRIPTION
I noticed when using `collections::String::push_str` with large slices that the performance was very poor compared to `std::string::String`.

I believe the reason is that std's `Vec` has a specialised implementation of `extend_from_slice` for `Vec<u8>`, but bumpalo's `Vec` does not (and probably can't without using nightly features).

Consequently, `push_str(str)` where `str` is 16 KB is currently equivalent to 16000 x individual calls to `push()` for each byte.

This PR fixes that by using `ptr::copy_nonoverlapping` to copy the entire slice in one go.

For a 16 KiB string, it's a 80x speed-up:

```
time:  [403.92 ns 429.47 ns 453.96 ns]                           
       thrpt:  [36.091 Gelem/s 38.149 Gelem/s 40.563 Gelem/s]
change:
       time:   [-98.836% -98.766% -98.700%] (p = 0.00 < 0.05)
       thrpt:  [+7592.7% +8002.3% +8491.5%]
       Performance has improved.
```

Also added a test for `push_str` with a long string, and a benchmark.

I've written the code in quite a verbose style with lengthy "SAFETY" comments. Maybe this is overkill, but you don't know me, so I wanted to make it clear from the code that the change is valid.