### PR TITLE
Improve performance of `String::from_str_in`

### DIFF
--- a/src/collections/string.rs
+++ b/src/collections/string.rs
@@ -680,8 +680,19 @@ impl<'bump> String<'bump> {
     /// assert_eq!(s, "hello");
     /// ```
     pub fn from_str_in(s: &str, bump: &'bump Bump) -> String<'bump> {
-        let mut t = String::with_capacity_in(s.len(), bump);
-        t.push_str(s);
+        let len = s.len();
+        let mut t = String::with_capacity_in(len, bump);
+        // SAFETY:
+        // * `src` is valid for reads of `s.len()` bytes by virtue of being an allocated `&str`.
+        // * `dst` is valid for writes of `s.len()` bytes as `String::with_capacity_in(s.len(), bump)`
+        //   above guarantees that.
+        // * Alignment is not relevant as `u8` has no alignment requirements.
+        // * Source and destination ranges cannot overlap as we just reserved the destination
+        //   range from the bump.
+        unsafe { ptr::copy_nonoverlapping(s.as_ptr(), t.vec.as_mut_ptr(), len) };
+        // SAFETY: We reserved sufficent capacity for the string above.
+        // The elements at `0..len` were initialized by `copy_nonoverlapping` above.
+        unsafe { t.vec.set_len(len) };
         t
     }
 

--- a/tests/all/string.rs
+++ b/tests/all/string.rs
@@ -17,3 +17,20 @@ fn trailing_comma_in_format_macro() {
     let v = format![in &b, "{}{}", 1, 2, ];
     assert_eq!(v, "12");
 }
+
+#[test]
+fn push_str() {
+    let b = Bump::new();
+    let mut s = String::new_in(&b);
+    s.push_str("abc");
+    assert_eq!(s, "abc");
+    s.push_str("def");
+    assert_eq!(s, "abcdef");
+    s.push_str("");
+    assert_eq!(s, "abcdef");
+    s.push_str(&"x".repeat(4000));
+    assert_eq!(s.len(), 4006);
+    s.push_str("ghi");
+    assert_eq!(s.len(), 4009);
+    assert_eq!(&s[s.len() - 5..], "xxghi");
+}


### PR DESCRIPTION
I investigated performance of `String::from_str_in`. Turns out that even after `String::push_str` is optimized (#229), the compiler does not figure out that bounds checks and various calculations can be elided.

So this change makes `from_str_in` about 18% faster for small strings.

PR includes a benchmark to demonstrate this.

Built on top of #229. If you're willing to merge, please merge that one first.

Sorry for sudden barrage of issues and PRs!