### PR TITLE
Adds `Vec::extend_from_slices_copy` that accepts multiple slices

### DIFF
--- a/src/collections/vec.rs
+++ b/src/collections/vec.rs
@@ -1894,11 +1894,11 @@ impl<'bump, T: 'bump + Copy> Vec<'bump, T> {
     pub fn extend_from_slices_copy(&mut self, slices: &[&[T]]) {
         // Reserve the total amount of capacity we'll need to safely append the aggregated contents
         // of each slice in `slices`.
-        let capacity_to_reserve: usize = slices.iter().map(|buf| buf.len()).sum();
+        let capacity_to_reserve: usize = slices.iter().map(|slice| slice.len()).sum();
         self.reserve(capacity_to_reserve);
 
         // SAFETY:
-        // * `dst` is valid for writes of `other.len()` bytes as `self.reserve(other.len())`
+        // * `dst` is valid for writes of `other.len()` items as `self.reserve(other.len())`
         //   above guarantees that.
         // * Source and destination ranges cannot overlap as we just reserved the destination
         //   range from the bump.

--- a/src/collections/vec.rs
+++ b/src/collections/vec.rs
@@ -1898,8 +1898,8 @@ impl<'bump, T: 'bump + Copy> Vec<'bump, T> {
         self.reserve(capacity_to_reserve);
 
         // SAFETY:
-        // * `dst` is valid for writes of `other.len()` items as `self.reserve(other.len())`
-        //   above guarantees that.
+        // * `dst` is valid for writes of `capacity_to_reserve` items as
+        //   `self.reserve(capacity_to_reserve)` above guarantees that.
         // * Source and destination ranges cannot overlap as we just reserved the destination
         //   range from the bump.
         unsafe {

--- a/tests/all/quickchecks.rs
+++ b/tests/all/quickchecks.rs
@@ -307,6 +307,7 @@ quickcheck! {
         }
     }
 
+    #[cfg(feature = "collections")]
     fn extending_from_slice(data1: Vec<usize>, data2: Vec<usize>) -> () {
         let bump = Bump::new();
 
@@ -325,6 +326,7 @@ quickcheck! {
         assert_eq!(&vec[data1.len()..], data2);
     }
 
+    #[cfg(feature = "collections")]
     fn extending_from_slices(data: Vec<Vec<usize>>) -> () {
         let bump = Bump::new();
 
@@ -354,6 +356,7 @@ quickcheck! {
         assert_eq!(vec.as_slice(), total_data.as_slice());
     }
 
+    #[cfg(feature = "collections")]
     fn compare_extending_from_slice_and_from_slices(data: Vec<Vec<usize>>) -> () {
         let bump = Bump::new();
 

--- a/tests/all/vec.rs
+++ b/tests/all/vec.rs
@@ -106,6 +106,41 @@ fn test_vec_items_get_dropped() {
     assert_eq!("Dropped!Dropped!", buffer.borrow().deref());
 }
 
+#[test]
+fn test_extend_from_slice_copy() {
+    let bump = Bump::new();
+    let mut vec = vec![in &bump; 1, 2, 3];
+    assert_eq!(&[1, 2, 3][..], vec.as_slice());
+
+    vec.extend_from_slice_copy(&[4, 5, 6]);
+    assert_eq!(&[1, 2, 3, 4, 5, 6][..], vec.as_slice());
+
+    // Confirm that passing an empty slice is a no-op
+    vec.extend_from_slice_copy(&[]);
+    assert_eq!(&[1, 2, 3, 4, 5, 6][..], vec.as_slice());
+
+    vec.extend_from_slice_copy(&[7]);
+    assert_eq!(&[1, 2, 3, 4, 5, 6, 7][..], vec.as_slice());
+}
+
+#[test]
+fn test_extend_from_slices_copy() {
+    let bump = Bump::new();
+    let mut vec = vec![in &bump; 1, 2, 3];
+    assert_eq!(&[1, 2, 3][..], vec.as_slice());
+
+    // Confirm that passing an empty slice of slices is a no-op
+    vec.extend_from_slices_copy(&[]);
+    assert_eq!(&[1, 2, 3][..], vec.as_slice());
+
+    // Confirm that an empty slice in the slice-of-slices is a no-op
+    vec.extend_from_slices_copy(&[&[4, 5, 6], &[], &[7]]);
+    assert_eq!(&[1, 2, 3, 4, 5, 6, 7][..], vec.as_slice());
+
+    vec.extend_from_slices_copy(&[&[8], &[9, 10, 11], &[12]]);
+    assert_eq!(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], vec.as_slice());
+}
+
 #[cfg(feature = "std")]
 #[test]
 fn test_vec_write() {


### PR DESCRIPTION
This PR builds on #236 by introducing an `extend_from_slices_copy` method.

The singular `extend_from_slice_copy` method calls `self.reserve()` before copying the input slice. In many circumstances, users will have several inputs to append at once; for example:

```rust
let mut vec = Vec::new_in(&bump);
vec.extend_from_slice_copy("foo".as_bytes()); // reserve() + memcpy
vec.extend_from_slice_copy("bar".as_bytes()); // reserve() + memcpy
vec.extend_from_slice_copy("baz".as_bytes()); // reserve() + memcpy
assert_eq!("foobarbaz".as_bytes(), vec.as_slice());
```

The compiler is often (always?) unable to optimize away the redundant calls to `reserve()`, which leads to assembly like the following:

![image](https://github.com/fitzgen/bumpalo/assets/611616/8c5c7b1c-7cef-4276-8dd7-ec09a54651ca)

If there is not sufficient space already allocated, it's possible for each intermediate call to `reserve` to cause a reallocation that could have been avoided if the total space required were known in advance.

The new `extend_from_slices_copy` method takes a slice-of-slices, allowing it to precompute the space required and perform a single call to `reserve`.

```rust
let mut vec = Vec::new_in(&bump);
vec.extend_from_slices_copy(&[ // reserve()
  "foo".as_bytes(), // memcpy
  "bar".as_bytes(), // memcpy
  "baz".as_bytes(), // memcpy
])
assert_eq!("foobarbaz".as_bytes(), vec.as_slice());
```

These benchmarks show the relative performance of the two methods when there are `N` slices to append and there is not sufficient memory allocated in advance:

![image](https://github.com/fitzgen/bumpalo/assets/611616/d087fce3-434b-42ce-8968-32c1504069df)

Note that there is a minor performance penalty for using `extend_from_slices_copy` when there's only one input slice. 

In the case where sufficient space has already been allocated in the `Bump` and `Vec` ahead of time, `extend_from_slices_copy` is faster by a narrower margin.

<details>
<summary>preallocated=true benchmark results</summary>

![image](https://github.com/fitzgen/bumpalo/assets/611616/0b22bf09-4674-4b78-ba9d-8c2381331da4)

</details>

Anecdotally, `extend_from_slices_copy` produces simpler assembly and the compiler also seems to be able to unroll the loops reliably when slice literals are being passed in (vs not-known-until-runtime and/or `black_box` slices, which is shown in the benchmarks above).