### PR TITLE
Implement minimum alignment

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         rust_channel: ["stable", "beta", "nightly", "1.73.0"]
-        feature_set: ["--features collections,boxed"]
+        feature_set: ["--features collections,boxed,min_align"]
         include:
           - rust_channel: "nightly"
             feature_set: "--all-features"
@@ -23,7 +23,7 @@ jobs:
             feature_set: "--no-default-features"
         exclude:
           - rust_channel: "nightly"
-            feature_set: "--features collections,boxed"
+            feature_set: "--features collections,boxed,min_align"
 
     runs-on: ubuntu-latest
     steps:
@@ -78,6 +78,8 @@ jobs:
       run: cargo test --verbose
     - name: Test under valgrind (features)
       run: cargo test --verbose --features collections,boxed
+    - name: Test under valgrind (features + min_align)
+      run: cargo test --verbose --features collections,boxed,min_align
 
   benches:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ collections = []
 boxed = []
 allocator_api = []
 std = []
+min_align = []
 
 # [profile.bench]
 # debug = true

--- a/README.md
+++ b/README.md
@@ -222,6 +222,14 @@ the unstable nightly`Allocator` API on stable Rust. This means that
 `bumpalo::Bump` will be usable with any collection that is generic over
 `allocator_api2::Allocator`.
 
+### Minimum alignment
+If the majority of your allocations are word aligned, than you might be able to
+get a modest speedup enabling the `min_align` feature. This will ensure all
+allocations are at least word aligned, which can save time in the alignment
+code. This may result in unused padding bytes for allocations with less than
+word alignment. As with any performance change, make sure you benchmark your
+application.
+
 ### Minimum Supported Rust Version (MSRV)
 
 This crate is guaranteed to compile on stable Rust **1.73** and up. It might

--- a/tests/all/alloc_fill.rs
+++ b/tests/all/alloc_fill.rs
@@ -1,4 +1,4 @@
-use bumpalo::Bump;
+use bumpalo::{Bump, MIN_ALIGN};
 use std::alloc::Layout;
 use std::cmp;
 use std::mem;
@@ -22,11 +22,11 @@ fn alloc_slice_fill_zero() {
     let alignment = cmp::max(mem::align_of::<u64>(), mem::align_of::<String>());
     assert_eq!(
         ptr1.as_ptr() as usize & !(alignment - 1),
-        ptr2 as *mut _ as usize
+        ptr2 as *mut _ as usize & !(MIN_ALIGN - 1),
     );
 
     let ptr3 = b.alloc_layout(layout);
-    assert_eq!(ptr2 as *mut _ as usize, ptr3.as_ptr() as usize + 1);
+    assert_eq!(ptr2 as *mut _ as usize, ptr3.as_ptr() as usize + MIN_ALIGN);
 }
 
 #[test]

--- a/tests/all/quickchecks.rs
+++ b/tests/all/quickchecks.rs
@@ -1,6 +1,6 @@
 use crate::quickcheck;
 use ::quickcheck::{Arbitrary, Gen};
-use bumpalo::Bump;
+use bumpalo::{Bump, MIN_ALIGN};
 use std::mem;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -187,7 +187,8 @@ quickcheck! {
 
     fn test_alignment_chunks(sizes: Vec<usize>) -> () {
         const SUPPORTED_ALIGNMENTS: &[usize] = &[1, 2, 4, 8, 16];
-        for &alignment in SUPPORTED_ALIGNMENTS {
+        let aligments = SUPPORTED_ALIGNMENTS.iter().filter(|x| **x >= MIN_ALIGN);
+        for &alignment in aligments {
             let mut b = Bump::with_capacity(513);
             let mut sizes = sizes.iter().map(|&size| (size % 10) * alignment).collect::<Vec<_>>();
 

--- a/tests/all/tests.rs
+++ b/tests/all/tests.rs
@@ -1,4 +1,4 @@
-use bumpalo::Bump;
+use bumpalo::{Bump, MIN_ALIGN};
 use std::alloc::Layout;
 use std::mem;
 use std::usize;
@@ -139,6 +139,11 @@ where
     T: Copy + Eq,
     I: Clone + Iterator<Item = T> + DoubleEndedIterator,
 {
+    // This test is not applicable if the minimum alignment is larger than the
+    // alignment of T
+    if MIN_ALIGN > std::mem::align_of::<T>() {
+        return;
+    }
     for &initial_size in &[0, 1, 8, 11, 0x1000, 0x12345] {
         let mut b = Bump::with_capacity(initial_size);
 


### PR DESCRIPTION
This is still failing for the `Allocator` API. I have tried to dig into why, but I was not able to narrow it down. It looks like we will change the alignment when reallocating/growing/shrinking, but I have not been able to determine where that is happening. Either way here is the benchmarks so far (everything with >2% difference).


```csv
group                                        min_align                               std
-----                                        ---------                               ---
alloc-with/medium                            1.00     20.6±0.16µs 463.2 MElem/sec    1.15     23.7±0.17µs 402.7 MElem/sec
alloc/medium                                 1.00     20.7±0.17µs 459.8 MElem/sec    1.13     23.4±0.26µs 408.3 MElem/sec
alloc/push_str                               1.06   267.0±94.31ns 57.2 GElem/sec     1.00   251.2±76.56ns 60.8 GElem/sec
extend 1024 bytes/extend                     1.00      2.1±0.04µs 461.6 MElem/sec    1.05      2.2±0.24µs 438.4 MElem/sec
extend 1024 bytes/extend_from_slice_copy     1.00     18.7±0.32ns 50.9 GElem/sec     1.06     19.8±2.19ns 48.2 GElem/sec
extend 11 bytes/extend_from_slice            1.04     24.7±1.48ns 423.9 MElem/sec    1.00     23.8±1.37ns 440.1 MElem/sec
extend 128 bytes/extend_from_slice           1.00    259.5±1.79ns 470.4 MElem/sec    1.03    266.9±4.87ns 457.3 MElem/sec
extend 16384 bytes/extend_from_slice_copy    1.00   221.6±43.66ns 68.9 GElem/sec     1.24   274.7±96.49ns 55.5 GElem/sec
extend 331 bytes/extend_from_slice_copy      1.00     10.6±0.20ns 29.0 GElem/sec     1.04     11.0±0.56ns 27.9 GElem/sec
extend 4096 bytes/extend_from_slice_copy     1.00     55.3±3.28ns 69.0 GElem/sec     1.04    57.5±14.89ns 66.3 GElem/sec
extend 64 bytes/extend_from_slice            1.00    129.9±0.86ns 470.0 MElem/sec    1.04    134.6±2.36ns 453.4 MElem/sec
extend 64 bytes/extend_from_slice_copy       1.00      5.2±0.05ns 11.5 GElem/sec     1.05      5.4±0.12ns 11.0 GElem/sec
try-alloc-try-with/big, big                  1.00   335.1±94.25µs 28.5 MElem/sec     1.04   349.2±95.87µs 27.3 MElem/sec
try-alloc-try-with/small, small              1.04     30.8±0.44µs 309.2 MElem/sec    1.00     29.8±0.31µs 320.5 MElem/sec
try-alloc-with/medium                        1.00     20.7±0.27µs 460.3 MElem/sec    1.15     23.7±0.22µs 402.0 MElem/sec
try-alloc/big                                1.00   237.4±11.62µs 40.2 MElem/sec     1.05   248.7±15.99µs 38.3 MElem/sec
try-alloc/medium                             1.00     20.8±0.26µs 457.6 MElem/sec    1.12     23.3±0.18µs 409.5 MElem/sec
```