### PR TITLE
Fixed stacked borrows violation in `dealloc` (fixes #247)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1705,6 +1705,7 @@ impl Bump {
         // If the pointer is the last allocation we made, we can reuse the bytes,
         // otherwise they are simply leaked -- at least until somebody calls reset().
         if self.is_last_allocation(ptr) {
+            let ptr = self.current_chunk_footer.get().as_ref().ptr.get();
             let ptr = NonNull::new_unchecked(ptr.as_ptr().add(layout.size()));
             self.current_chunk_footer.get().as_ref().ptr.set(ptr);
         }

--- a/tests/all/tests.rs
+++ b/tests/all/tests.rs
@@ -209,3 +209,14 @@ fn test_chunk_capacity() {
     b.alloc(true);
     assert!(b.chunk_capacity() < orig_capacity);
 }
+
+#[test]
+#[cfg(feature = "allocator_api")]
+fn miri_stacked_borrows_issue_247() {
+    let bump = bumpalo::Bump::new();
+
+    let a = Box::into_raw(Box::new_in(1u8, &bump));
+    drop(unsafe { Box::from_raw_in(a, &bump) });
+
+    let _b = Box::new_in(2u16, &bump);
+}


### PR DESCRIPTION
In some strange edge case miri complains about a stacked borrows violation (see #247). I don't understand why the violation gets triggered in this particular case.

But when using the pointer from the footer instead of using the parameter provided one, miri won't complain anymore.