### PR TITLE
Reduce rust-version to 1.71.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 repository = "https://github.com/fitzgen/bumpalo"
 version = "3.16.0"
 exclude = ["/.github/*", "/benches", "/tests", "valgrind.supp", "bumpalo.png"]
-rust-version = "1.73.0"
+rust-version = "1.71.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ the unstable nightly`Allocator` API on stable Rust. This means that
 
 ### Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust **1.73** and up. It might
+This crate is guaranteed to compile on stable Rust **1.71.1** and up. It might
 compile with older versions but that may change in any new patch release.
 
 We reserve the right to increment the MSRV on minor releases, however we will


### PR DESCRIPTION
As far as I can tell, the crate compiles fine against rustc 1.71.1, which is the rustc version of Debian trixie: https://packages.debian.org/testing/rustc. Thus, for the benefit of distro packagers and others that might be using old versions of rustc, it would be neat if rust-version could be reduced to 1.71.1.