### PR TITLE
Add integration with zerocopy crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,11 @@ harness = false
 # implement its `Allocator` trait.
 allocator-api2 = { version = "0.2.8", default-features = false, optional = true }
 
+# This dependency enables integration with the zerocopy trait, which allows
+# allocating values that implement FromZeroes directly in a Bump.
+zerocopy = { version = "0.7.34", default-features = false, optional = true }
+zerocopy-derive = { version = "0.7.34", default-features = false, optional = true }
+
 # This dependency is here to allow integration with Serde, if the `serde` feature is enabled
 serde = { version = "1.0.171", optional = true }
 
@@ -53,6 +58,7 @@ boxed = []
 allocator_api = []
 std = []
 serde = ["dep:serde"]
+zerocopy = ["dep:zerocopy", "dep:zerocopy-derive"]
 
 # [profile.bench]
 # debug = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,9 @@ pub mod boxed;
 #[cfg(feature = "collections")]
 pub mod collections;
 
+#[cfg(feature = "zerocopy")]
+mod zerocopy_integration;
+
 mod alloc;
 
 use core::cell::Cell;

--- a/src/zerocopy_integration.rs
+++ b/src/zerocopy_integration.rs
@@ -1,0 +1,98 @@
+//! This module provides integration with the `zerocopy` crate. `zerocopy` defines traits and
+//! methods which allow for _safely_ transmuting types and for safely converting types to/from
+//! byte buffers.
+
+use crate::Bump;
+use core::ptr::NonNull;
+use core_alloc::alloc::Layout;
+use zerocopy::FromZeroes;
+
+impl Bump {
+    /// Allocates `T` by filling it with zeroes.
+    ///
+    /// This function allocates `T` directly in the `Bump` without initializing an instance of it
+    /// on the stack. This is possible due to the `T: FromZeroes` constraint, which specifies that
+    /// `T` may be safely constructed from an all-zeroes bit pattern.
+    ///
+    /// This avoids the "placement new" problem with using `Box::new()` on large types. Allocating
+    /// a large type using `Box::new()` requires first constructing the large type on the stack,
+    /// then moving it into a heap allocation. This can cause stack overflow.  Using
+    /// `Bump::alloc_zeroed` avoids this problem.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bumpalo::Bump;
+    ///
+    /// #[repr(C)]
+    /// #[derive(zerocopy_derive::FromZeroes)]
+    /// struct MyData {
+    ///     x: u32,
+    ///     y: u8,
+    ///     big_buffer: [u8; 0x10000],
+    /// }
+    ///
+    /// let b = Bump::new();
+    /// let my_data: &mut MyData = b.alloc_zeroed();
+    /// my_data.big_buffer[0] = 42;
+    /// ```
+    pub fn alloc_zeroed<T: FromZeroes>(&self) -> &mut T {
+        let layout = Layout::new::<T>();
+        if layout.size() == 0 {
+            // SAFETY: For ZSTs, NonNull::dangling() is a permissible address.
+            unsafe {
+                return NonNull::dangling().as_mut();
+            }
+        }
+
+        let p = self.alloc_layout(layout);
+
+        // SAFETY: The FromZeroes trait means means that zero-filling this allocation is a valid
+        // initialization of it, for T.
+        unsafe {
+            p.as_ptr().write_bytes(0, layout.size());
+            &mut *(p.as_ptr() as *mut T)
+        }
+    }
+
+    /// Allocates `[T]` of the given length by filling it with zeroes.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bumpalo::Bump;
+    /// #[repr(C)]
+    /// #[derive(zerocopy_derive::FromZeroes)]
+    /// struct MyData {
+    ///     x: u32,
+    ///     y: u8,
+    ///     big_buffer: [u8; 0x10000],
+    /// }
+    ///
+    /// let b = Bump::new();
+    /// let my_data: &mut [MyData] = b.alloc_slice_zeroed(1000);
+    /// my_data[0].big_buffer[0] = 42;
+    /// ```
+    pub fn alloc_slice_zeroed<T: FromZeroes>(&self, len: usize) -> &mut [T] {
+        if len == 0 {
+            return &mut [];
+        }
+
+        if core::mem::size_of::<T>() == 0 {
+            // SAFETY: For ZSTs, NonNull::dangling() is a permissible address, even for arrays.
+            unsafe {
+                return core::slice::from_raw_parts_mut(NonNull::dangling().as_mut(), len);
+            }
+        }
+
+        let layout = Layout::array::<T>(len).unwrap();
+        let p = self.alloc_layout(layout);
+
+        // SAFETY: The FromZeroes trait means means that zero-filling this allocation is a valid
+        // initialization of it, for T.
+        unsafe {
+            p.as_ptr().write_bytes(0, layout.size());
+            core::slice::from_raw_parts_mut(p.as_ptr() as *mut T, len)
+        }
+    }
+}

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -19,4 +19,7 @@ mod vec;
 #[cfg(feature = "serde")]
 mod serde;
 
+#[cfg(feature = "zerocopy")]
+mod zerocopy_integration;
+
 fn main() {}

--- a/tests/all/zerocopy_integration.rs
+++ b/tests/all/zerocopy_integration.rs
@@ -1,0 +1,83 @@
+//! This tests integration with the `zerocopy` crate, which allows direct allocation of types
+//! that can be safely constructed from an all-zeroes bit pattern.
+
+use bumpalo::Bump;
+use zerocopy_derive::FromZeroes;
+
+#[repr(C)]
+#[derive(FromZeroes)]
+struct Foo {
+    a: u32,
+    b: u8,
+    // <-- 3 bytes of padding
+}
+
+#[test]
+fn alloc_zeroed() {
+    let b = Bump::new();
+    let f = b.alloc_zeroed::<Foo>();
+    assert_eq!(f.a, 0);
+    assert_eq!(f.b, 0);
+}
+
+#[test]
+fn alloc_slice_zeroed() {
+    let b = Bump::new();
+    let s = b.alloc_slice_zeroed::<Foo>(10);
+    assert_eq!(s.len(), 10);
+    assert_eq!(s[0].a, 0);
+    assert_eq!(s[9].a, 0);
+}
+
+#[test]
+fn alloc_slice_zeroed_empty() {
+    let b = Bump::new();
+    let s = b.alloc_slice_zeroed::<Foo>(0);
+    assert!(s.is_empty());
+}
+
+// Types outside of this crate also implement FromZeroes.
+// bool implements FromZeroes, although it does _not_ implement FromBytes.
+#[test]
+fn alloc_slice_zeroed_external() {
+    let b = Bump::new();
+    let s = b.alloc_slice_zeroed::<bool>(10);
+    assert_eq!(s.len(), 10);
+    assert!(!s[0]);
+}
+
+#[repr(C)]
+#[derive(FromZeroes)]
+struct Empty {}
+
+#[test]
+fn alloc_zeroed_zst() {
+    let b = Bump::new();
+    b.alloc_zeroed::<Empty>();
+}
+
+#[test]
+fn alloc_slice_zeroed_zst() {
+    let b = Bump::new();
+    let s = b.alloc_slice_zeroed::<Empty>(10);
+    assert_eq!(s.len(), 10);
+}
+
+#[test]
+fn alloc_slice_zeroed_zst_empty() {
+    let b = Bump::new();
+    let s = b.alloc_slice_zeroed::<Empty>(0);
+    assert!(s.is_empty());
+}
+
+// Allocate a large object directly in a Bump. This avoids the problem of
+// Box::new() for large types, where the type is constructed on the stack
+// _before_ the heap allocation. This pattern (when using Box::new()) can
+// cause stack overflow, but when using Bump::alloc_zeroed() the object is
+// allocated directly in the heap.
+#[test]
+fn alloc_zeroed_big() {
+    let b = Bump::new();
+    let big = b.alloc_zeroed::<[u32; 0x10000]>();
+    assert_eq!(big.len(), 0x10000);
+}


### PR DESCRIPTION
The zerocopy crate provides traits and functions for _safely_ transmuting types to/from bytes. It is an important building block for high-performance serialization in many designs. It is also a very well-maintained crate with high standards for quality and its maintainers are actively engaged with the Rust Project on advancing the goals of the Safe Transmute working group.

The `zerocopy` crate defines the `FromZeroes` trait, which specifies that a type can be safely constructed from a buffer containing an all-zeroes bit pattern.

This PR adds two new methods to `Bump`: `new_zeroed` and `new_slice_zeroed`. `new_zeroed` allocates space for `T` (where `T: FromZeroes`) and returns `&mut T`. This avoids the "placement new" problem in Rust, which causes problems when attempting to allocate large types in the heap, such as `[u8; 0x10000]`. For most containers, such as `Box`, the type is briefly constructed in a temporary on the stack, then a heap allocation is done, then the value is moved into the heap allocation. If `T` is large enough, it can cause stack overflow.

The `Bump::new_zeroed` function avoids this problem by simply allocating space for `T` directly in the heap, then filling it with zeroes, then casting the allocation as `&mut T` and returning it. The `FromZeroes` constraint ensures that this is sound.

The `new_slice_zeroed` function similarly allows allocating slices directly in a Bump.