### PR TITLE
use primitive type u64 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ and then start bump allocating into this new memory chunk.
 
 ```rust
 use bumpalo::Bump;
-use std::u64;
 
 struct Doggo {
     cuteness: u64,
@@ -63,7 +62,7 @@ let bump = Bump::new();
 
 // Allocate values into the arena.
 let scooter = bump.alloc(Doggo {
-    cuteness: u64::max_value(),
+    cuteness: u64::MAX,
     age: 8,
     scritches_required: true,
 });


### PR DESCRIPTION
Hi!
module [std::u64](https://doc.rust-lang.org/std/u64/index.html) is deprecated.
method [max_value](https://doc.rust-lang.org/std/primitive.u64.html#method.max_value) also deprecated