### PR TITLE
Fix benches reproducing instructions

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -74,7 +74,7 @@ To update the tables below, use `cargo-criterion` and [`criterion-table`]:
 
 ```
 $ cd bumpalo/benches/
-$ cargo +nightly bench --features bench_allocator_api \
+$ cargo +nightly criterion --features bench_allocator_api \
     --bench allocator_api \
     --message-format=json \
     > results.json


### PR DESCRIPTION
Just fixing a typo. `cargo-criterion` is mentioned but the code block uses `cargo bench` instead which doesn't work with `criterion-table`.

---

I've done some runs of these benchmarks and like you I couldn't reproduce the results of zakarumych but I also got quite different results than yours. I did not get terribly consistent results and sometimes big outliers cropped up like run #<!---->2's `allocate([u8; 32]) x 10007` and run #<!---->4's `allocate(u8) x 10007`. Here they are if you're curious:

- <https://github.com/fitzgen/bumpalo/compare/main...bluurryy:bumpalo:my-bench-run>
- <https://github.com/fitzgen/bumpalo/compare/main...bluurryy:bumpalo:my-bench-run-2>
- <https://github.com/fitzgen/bumpalo/compare/main...bluurryy:bumpalo:my-bench-run-3>
- <https://github.com/fitzgen/bumpalo/compare/main...bluurryy:bumpalo:my-bench-run-4>

*The benchmarks were run using `rustc 1.89.0-nightly (8da623945 2025-06-13)` on `x86_64-unknown-linux-gnu` with a `Intel® Core™ i5-4570S CPU @ 2.90GHz`.*

---

That drove me to create some benchmarks using `iai-callgrind`, measuring instructions and branches instead. 
I've used some cases from this benchmark and added cases to check the impact of `MIN_ALIGN`.
You can see them here: <https://github.com/bluurryy/bump-scope/tree/main/crates/callgrind-benches>

A nice side effect is that they are very fast to run.

Cheers.
 