### PR TITLE
Vec::retain_mut

### DIFF
--- a/src/collections/vec.rs
+++ b/src/collections/vec.rs
@@ -1295,12 +1295,36 @@ impl<'bump, T: 'bump> Vec<'bump, T> {
     /// let b = Bump::new();
     ///
     /// let mut vec = bumpalo::vec![in &b; 1, 2, 3, 4];
-    /// vec.retain(|&x| x % 2 == 0);
+    /// vec.retain(|x: &i32| *x % 2 == 0);
     /// assert_eq!(vec, [2, 4]);
     /// ```
     pub fn retain<F>(&mut self, mut f: F)
     where
         F: FnMut(&T) -> bool,
+    {
+        self.drain_filter(|x| !f(x));
+    }
+
+    /// Retains only the elements specified by the predicate.
+    ///
+    /// In other words, remove all elements `e` such that `f(&mut e)` returns `false`.
+    /// This method operates in place and preserves the order of the retained
+    /// elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bumpalo::{Bump, collections::Vec};
+    ///
+    /// let b = Bump::new();
+    ///
+    /// let mut vec = bumpalo::vec![in &b; 1, 2, 3, 4];
+    /// vec.retain_mut(|x: &mut i32| *x % 2 == 0);
+    /// assert_eq!(vec, [2, 4]);
+    /// ```
+    pub fn retain_mut<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&mut T) -> bool,
     {
         self.drain_filter(|x| !f(x));
     }


### PR DESCRIPTION
Added a `Vec::retain_mut` method.
Yes, this is functionally equivalent to calling `Vec::drain_filter` and ignoring the iterator, but the API is closer to that of the Rust standard library and will be easier to find for those looking.