### PR TITLE
Bump allocator-api2 to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ harness = false
 # This dependency provides a version of the unstable nightly Rust `Allocator`
 # trait on stable Rust. Enabling this feature means that `bumpalo` will
 # implement its `Allocator` trait.
-allocator-api2 = { version = "0.2.8", default-features = false, optional = true }
+allocator-api2 = { version = "0.3.0", default-features = false, optional = true }
 
 # This dependency is here to allow integration with Serde, if the `serde` feature is enabled
 serde = { version = "1.0.171", optional = true }

--- a/tests/all/tests.rs
+++ b/tests/all/tests.rs
@@ -223,7 +223,7 @@ fn test_chunk_capacity() {
 fn miri_stacked_borrows_issue_247() {
     let bump = bumpalo::Bump::new();
 
-    let a = Box::into_raw(Box::new_in(1u8, &bump));
+    let (a, _) = Box::into_raw_with_allocator(Box::new_in(1u8, &bump));
     drop(unsafe { Box::from_raw_in(a, &bump) });
 
     let _b = Box::new_in(2u16, &bump);


### PR DESCRIPTION
I do not know how breaking that change is, so I’ll just highlight that I did _not_ touch
the version in `Cargo.toml`
