### PR TITLE
Add inline attribute to String::from_str_in

### DIFF
--- a/src/collections/string.rs
+++ b/src/collections/string.rs
@@ -679,6 +679,7 @@ impl<'bump> String<'bump> {
     /// let s = String::from_str_in("hello", &b);
     /// assert_eq!(s, "hello");
     /// ```
+    #[inline]
     pub fn from_str_in(s: &str, bump: &'bump Bump) -> String<'bump> {
         let len = s.len();
         let mut t = String::with_capacity_in(len, bump);


### PR DESCRIPTION
Saw that `String::from_str_in` pop up in my own application benchmark profiling. It seems like a good candidate for inlining as `String::with_capacity_in` is inlined and `String::from_str_in` isn't doing much work other than that.

Running the bumpalo benchmarks, the `from_str_in` benchmark did not see any changes, though my own benchmarks show a consistent 5-10% improvement in latency.