### PR TITLE
Add `run_scoped` method to run closures and conditionally perform partial resets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2674,7 +2674,7 @@ mod tests {
         let allocated = bump.allocated_bytes();
         let remaining_capacity = bump.chunk_capacity();
 
-        for _ in 0..10000 {
+        for _ in 0..100 {
             // Since the scoped function returns `None` the allocator should partially reset after each run
             bump.run_scoped(|alloc| {
                 let bar = alloc.alloc_str("bar");


### PR DESCRIPTION
This PR adds a "CheckPoint" struct that can be used to save a position for a Bump that can be later reset to, allowing for partial resets of the allocator.

I have a use case where I build a collection from many complex structs that use a bump allocator, however these structs must pass a filter before being added to the collection, In cases where very few events make it through the filter I found that the bump allocator would grow to be massive due to leaked allocations from rejected structs.
After testing using a second bump allocator as scratch space that resolved the memory leak issue however caused a ~20% performance hit due to the extra memory copies, this PR solves the problem by taking a checkpoint before building the complex struct, then performing a partial reset if the struct is rejected.

Not sure if this kind of conditional logic is used elsewhere but figured I'd make a PR anyway in case it's useful, happy to update docs etc if needed.