### PR TITLE
Add pop_if() to Vec

### DIFF
--- a/src/collections/vec.rs
+++ b/src/collections/vec.rs
@@ -1531,7 +1531,11 @@ impl<'bump, T: 'bump> Vec<'bump, T> {
     #[inline]
     pub fn pop_if(&mut self, predicate: impl FnOnce(&mut T) -> bool) -> Option<T> {
         let last = self.last_mut()?;
-        if predicate(last) { self.pop() } else { None }
+        if predicate(last) {
+            self.pop()
+        } else {
+            None
+        }
     }
 
     /// Moves all the elements of `other` into `Self`, leaving `other` empty.


### PR DESCRIPTION
Bumpalo's implementation of Vec is missing some of the methods that the stdlib has added to Vec since it was forked. This PR adds pop_if(), which has been stable in the stdlib since 1.86.