### PR TITLE
Make box covariant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ allocator-api2 = { version = "0.2.8", default-features = false, optional = true 
 serde = { version = "1.0.171", optional = true }
 
 [dev-dependencies]
-quickcheck = "1.0.3"
+quickcheck = "=1.0.3"
 criterion = "0.3.6"
 rand = "0.8.5"
 serde = { version = "1.0.197", features = ["derive"] }

--- a/tests/all/boxed.rs
+++ b/tests/all/boxed.rs
@@ -12,3 +12,24 @@ fn into_raw_aliasing() {
     let mut_ref = unsafe { &mut *raw };
     dbg!(mut_ref);
 }
+
+// This tests some basic functionality of the box.
+#[test]
+fn test_box_basic() {
+    let bump = Bump::new();
+    let mut value = Box::new_in("hello".to_string(), &bump);
+    assert_eq!("hello", &*value);
+    *value = "world".to_string();
+    assert_eq!("world", &*value);
+}
+
+// This function tests that Box is covariant.
+// If you change the PhantomData<&'a T> in Box to PhantomData<&'a mut T> the test fails the borrow checker.
+fn _box_is_covariant<'sup, 'sub: 'sup>(
+    a: Box<&'sup u32>,
+    b: Box<&'sub u32>,
+    f: impl Fn(Box<&'sup u32>),
+) {
+    f(a);
+    f(b);
+}


### PR DESCRIPTION
This CR makes the box covariant in 'a to allow for more use cases. This addresses #170.

Making it covariant should be OK for the same reasons as the standard library box is safe. Quoting the RustNomicon (https://doc.rust-lang.org/nomicon/subtyping.html)

> As it turns out, the argument for why it's ok for Box (and Vec, HashMap, etc.) to be covariant is pretty similar to the argument for why it's ok for lifetimes to be covariant: as soon as you try to stuff them in something like a mutable reference, they inherit invariance and you're prevented from doing anything bad.

The Bumpalo Vec is already covariant. 

I tested this code by running

    cargo test --features boxed 

I checked that all tests passed. I also added a unit test for covariance. I wasn't able to come up with a great test, but I verified that the test fails if I make the lifetime invariant. 

I additionally ran 

    cargo miri test --features boxed

miri passed all tests. It complains about some memory leaks in raw_vec, but that should be unrelated. 