### PR TITLE
Pin quickcheck

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ allocator-api2 = { version = "0.2.8", default-features = false, optional = true 
 serde = { version = "1.0.171", optional = true }
 
 [dev-dependencies]
-quickcheck = "1.0.3"
+quickcheck = "=1.0.3"
 criterion = "0.3.6"
 rand = "0.8.5"
 serde = { version = "1.0.197", features = ["derive"] }


### PR DESCRIPTION
This is needed to maintain the MSRV, see the failing build on https://github.com/fitzgen/bumpalo/pull/304. 

The underlying issue is that newer versions of quickcheck depend on a version of rand that is incompatible with Bumpalo's MSRV.
