### PR TITLE
Restore Send and Sync for Box

### DIFF
--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -677,6 +677,12 @@ impl<'a, T: ?Sized> AsMut<T> for Box<'a, T> {
 
 impl<'a, T: ?Sized> Unpin for Box<'a, T> {}
 
+// Safety: If T is Send the box is too because Box has exclusive access to its wrapped T.
+unsafe impl<'a, T: Send> Send for Box<'a, T> {}
+
+// Safety: If T is Sync the box is too because Box has exclusive access to its wrapped T.
+unsafe impl<'a, T: Sync> Sync for Box<'a, T> {}
+
 impl<'a, F: ?Sized + Future + Unpin> Future for Box<'a, F> {
     type Output = F::Output;
 


### PR DESCRIPTION
The PR https://github.com/fitzgen/bumpalo/pull/304 broke Send and Sync auto trait impls for Box. This was raised in issue https://github.com/fitzgen/bumpalo/issues/308. 

This PR fixes that issue by implementing Send and Sync for Box if the wrapped value is Send and Sync respectively. 

After this PR, cargo-semver-checks is green. 


    cargo semver-checks --baseline-version 3.19.1
        Building bumpalo v3.20.0 (current)
          Built [   0.551s] (current)
        Parsing bumpalo v3.20.0 (current)
          Parsed [   0.005s] (current)
        Parsing bumpalo v3.19.1 (baseline, cached)
          Parsed [   0.005s] (baseline)
        Checking bumpalo v3.19.1 -> v3.20.0 (minor change)
        Checked [   0.015s] 196 checks: 196 pass, 49 skip
        Summary no semver update required
        Finished [   0.893s] bumpalo