### PR TITLE
fix: fix typo in comment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2055,7 +2055,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
             // Set the new chunk as our new current chunk.
             self.current_chunk_footer.set(new_footer);
 
-            // And then we can rely on `tray_alloc_layout_fast` to allocate
+            // And then we can rely on `try_alloc_layout_fast` to allocate
             // space within this chunk.
             let ptr = self.try_alloc_layout_fast(layout);
             debug_assert!(ptr.is_some());


### PR DESCRIPTION
Just fix a typo.