### PR TITLE
test: fix test for OOM instead of overflow

### DIFF
--- a/tests/all/tests.rs
+++ b/tests/all/tests.rs
@@ -71,8 +71,13 @@ fn oom_instead_of_bump_pointer_overflow() {
     let x = bump.alloc(0_u8);
     let p = x as *mut u8 as usize;
 
+    // Prevent bump from allocating a new chunk.
+    bump.set_allocation_limit(Some(bump.allocated_bytes()));
+
     // A size guaranteed to overflow the bump pointer.
-    let size = (isize::MAX as usize) - p + 1;
+    // We assume that heap allocations are made in bottom half of address space, so `size < isize::MAX`.
+    // If that assumption is incorrect, `Layout::from_size_align` will return `Err` and the test will fail.
+    let size = p + 1;
     let align = 1;
     let layout = match Layout::from_size_align(size, align) {
         Err(e) => {


### PR DESCRIPTION
This test appears to be outdated.

It was originally introduced in e53e7713205984dfc8165045e1e67ea784d95fdf, and then modified in a22176231600fe96408e7fd8889c16301de06d20.

The test was introduced (by the looks of it) before Bumpalo switched to bumping downwards. When bumping upwards, `size = usize::MAX - p + 1` made sense as a value which would be guaranteed overflow the bump pointer.

a22176231600fe96408e7fd8889c16301de06d20 fixed failures on nightly, but did not alter the basic logic. It changed `size = (isize::MAX as usize) - p + 1`.

On 64-bit platforms, this did still produce `size` values which would underflow in `chunk_cursor_ptr.wrapping_sub(size)`, but more by accident than design - only because pointers don't use full 64-bit address space so `p < (1 << 48)`. On 32-bit platforms where it's possible `p` could be e.g. `0x3FFF_F000`, `size` could be small, it might not underflow, and the test could fail because `alloc_layout` succeeds.

Fix this test by:

1. Making `size = p + 1`. `bump_cursor.wrapping_sub(size)` is guaranteed to wrap around with this value of `size`.
2. Setting an allocation limit, so `bump` cannot allocate a new chunk to service the allocation request (possibly it could do successfully if `p` is small).

The test does assume that allocations are always made in bottom half of address space. If they're not, `size` will be `> isize::MAX` and `Layout::from_size_align` will return `Err`, so the test will fail.

That assumption was already implicit in the test - previously if `p > isize::MAX`, then calculating `size` would involve arithmetic overflow, which would panic.

This assumption is (to my knowledge) fairly safe on 64-bit platforms, where top half of address space is typically reserved for the kernel. But I'm not sure if it is safe on 32-bit platforms e.g. WASM - perhaps they may use the full 32-bit address space for heap.