### PR TITLE
Add an "emplace" family of APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,14 +194,6 @@ std only trait implementations for some collections:
 
 * `std::io::Write` for `Vec<'bump, u8>`
 
-### Thread support
-
-The `Bump` is `!Sync`, which makes it hard to use in certain situations around
-threads ‒ for example in `rayon`.
-
-The [`bumpalo-herd`](https://crates.io/crates/bumpalo-herd) crate provides a
-pool of `Bump` allocators for use in such situations.
-
 ### Nightly Rust `allocator_api` Support
 
 The unstable, nightly-only Rust `allocator_api` feature defines an [`Allocator`]

--- a/src/emplace.rs
+++ b/src/emplace.rs
@@ -1,0 +1,1288 @@
+use super::{oom, AllocErr, Bump, RewindGuard};
+use core::alloc::Layout;
+use core::fmt;
+use core::mem::{self, MaybeUninit};
+use core::ptr::{self, NonNull};
+use core::slice;
+use core::str;
+
+/// An in-place allocation builder for a single value of type `T`.
+///
+/// Created by [`Bump::emplace`] or [`Bump::try_emplace`]. Space for `T` is
+/// allocated when the `Emplace` is created, and initialization is deferred
+/// until you call [`write`](Emplace::write) or
+/// [`assume_init`](Emplace::assume_init).
+///
+/// If the `Emplace` is dropped without being finalized, the allocation is
+/// automatically rewound (reclaimed) in the bump allocator.
+///
+/// ## Example
+///
+/// ```
+/// let bump = bumpalo::Bump::new();
+/// let x = bump.emplace().write(42u64);
+/// assert_eq!(*x, 42);
+/// ```
+pub struct Emplace<'a, T, const MIN_ALIGN: usize> {
+    guard: RewindGuard<'a, MIN_ALIGN>,
+    ptr: NonNull<MaybeUninit<T>>,
+}
+
+impl<T, const MIN_ALIGN: usize> fmt::Debug for Emplace<'_, T, MIN_ALIGN> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Emplace").field("ptr", &self.ptr).finish()
+    }
+}
+
+impl<'a, T, const MIN_ALIGN: usize> Emplace<'a, T, MIN_ALIGN> {
+    /// # Safety
+    ///
+    /// `guard` must wrap a pointer that is valid for `MaybeUninit<T>`.
+    pub(crate) unsafe fn new(guard: RewindGuard<'a, MIN_ALIGN>) -> Self {
+        let ptr = guard.ptr.cast::<MaybeUninit<T>>();
+        Self { guard, ptr }
+    }
+
+    /// Get a shared reference to the underlying `MaybeUninit<T>`.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let place = bump.emplace::<u64>();
+    /// let uninit: &std::mem::MaybeUninit<u64> = place.as_uninit();
+    /// drop(place);
+    /// ```
+    #[inline]
+    pub fn as_uninit(&self) -> &MaybeUninit<T> {
+        unsafe { self.ptr.as_ref() }
+    }
+
+    /// Get an exclusive reference to the underlying `MaybeUninit<T>`.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use std::mem::MaybeUninit;
+    ///
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace::<u32>();
+    /// place.as_uninit_mut().write(99);
+    /// let val = unsafe { place.assume_init() };
+    /// assert_eq!(*val, 99);
+    /// ```
+    #[inline]
+    pub fn as_uninit_mut(&mut self) -> &mut MaybeUninit<T> {
+        unsafe { self.ptr.as_mut() }
+    }
+
+    /// Finalize this place, assuming the value has been initialized.
+    ///
+    /// # Safety
+    ///
+    /// The caller must have fully initialized the `MaybeUninit<T>` (e.g. via
+    /// [`as_uninit_mut`](Emplace::as_uninit_mut)) before calling this method.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace::<u32>();
+    /// place.as_uninit_mut().write(42);
+    /// let val = unsafe { place.assume_init() };
+    /// assert_eq!(*val, 42);
+    /// ```
+    #[inline]
+    pub unsafe fn assume_init(self) -> &'a mut T {
+        self.guard.finish();
+        unsafe { &mut *self.ptr.as_ptr().cast::<T>() }
+    }
+
+    /// Finalize this place, returning the raw `MaybeUninit<T>` without
+    /// requiring initialization.
+    ///
+    /// The caller is responsible for ensuring the memory is properly
+    /// initialized before the returned reference is read.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let place = bump.emplace::<u64>();
+    /// let uninit: &mut std::mem::MaybeUninit<u64> = place.into_uninit();
+    /// uninit.write(123);
+    /// let val = unsafe { uninit.assume_init_ref() };
+    /// assert_eq!(*val, 123);
+    /// ```
+    #[inline]
+    pub fn into_uninit(self) -> &'a mut MaybeUninit<T> {
+        self.guard.finish();
+        unsafe { &mut *self.ptr.as_ptr() }
+    }
+
+    /// Write a value into this place and return an exclusive reference to it.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let x = bump.emplace().write(42u64);
+    /// assert_eq!(*x, 42);
+    /// ```
+    #[inline]
+    pub fn write(self, value: T) -> &'a mut T {
+        unsafe {
+            ptr::write(self.ptr.as_ptr().cast::<T>(), value);
+            self.assume_init()
+        }
+    }
+}
+
+/// An in-place allocation builder for slices of `T`.
+///
+/// Created by [`Bump::emplace_slice`], [`Bump::emplace_slice_with_capacity`],
+/// or their `try_*` variants. Elements can be added incrementally via
+/// [`push`](EmplaceSlice::push), [`extend`](EmplaceSlice::extend), or
+/// [`extend_from_slice_copy`](EmplaceSlice::extend_from_slice_copy), or all
+/// at once via [`copy_slice`](EmplaceSlice::copy_slice),
+/// [`clone_slice`](EmplaceSlice::clone_slice), or
+/// [`write_iter`](EmplaceSlice::write_iter).
+///
+/// Finalize with [`into_mut_slice`](EmplaceSlice::into_mut_slice) or
+/// [`into_slice`](EmplaceSlice::into_slice) to get the resulting bump-allocated
+/// slice. If dropped without finalizing, the allocation is automatically
+/// rewound.
+///
+/// ## Example
+///
+/// ```
+/// let bump = bumpalo::Bump::new();
+/// let mut place = bump.emplace_slice::<u8>();
+/// place.push(1);
+/// place.push(2);
+/// place.push(3);
+/// let slice = place.into_mut_slice();
+/// assert_eq!(slice, &[1, 2, 3]);
+/// ```
+pub struct EmplaceSlice<'a, T, const MIN_ALIGN: usize> {
+    inner: Emplace<'a, T, MIN_ALIGN>,
+    len: usize,
+    capacity: usize,
+}
+
+impl<T, const MIN_ALIGN: usize> fmt::Debug for EmplaceSlice<'_, T, MIN_ALIGN> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EmplaceSlice")
+            .field("ptr", &self.base_ptr())
+            .field("len", &self.len)
+            .field("capacity", &self.capacity)
+            .finish()
+    }
+}
+
+impl<'a, T, const MIN_ALIGN: usize> EmplaceSlice<'a, T, MIN_ALIGN>
+where
+    T: Sized,
+{
+    /// # Safety
+    ///
+    /// `guard` must wrap a pointer that is valid for `MaybeUninit<T>`.
+    pub(crate) unsafe fn new(guard: RewindGuard<'a, MIN_ALIGN>, capacity: usize) -> Self {
+        Self {
+            inner: Emplace::new(guard),
+            len: 0,
+            capacity,
+        }
+    }
+
+    fn base_ptr(&self) -> *mut T {
+        self.inner.ptr.as_ptr().cast::<T>()
+    }
+
+    fn bump(&self) -> &'a Bump<MIN_ALIGN> {
+        self.inner.guard.bump
+    }
+
+    /// Get the full capacity as a shared slice of `MaybeUninit<T>`.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let place = bump.emplace_slice_with_capacity::<u8>(4);
+    /// assert!(place.as_uninit().len() >= 4);
+    /// drop(place);
+    /// ```
+    #[inline]
+    pub fn as_uninit(&self) -> &[MaybeUninit<T>] {
+        unsafe { slice::from_raw_parts(self.base_ptr().cast::<MaybeUninit<T>>(), self.capacity) }
+    }
+
+    /// Get the full capacity as an exclusive slice of `MaybeUninit<T>`.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use std::mem::MaybeUninit;
+    ///
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice_with_capacity::<u32>(4);
+    /// place.as_uninit_mut()[0] = MaybeUninit::new(42);
+    /// drop(place);
+    /// ```
+    #[inline]
+    pub fn as_uninit_mut(&mut self) -> &mut [MaybeUninit<T>] {
+        unsafe {
+            slice::from_raw_parts_mut(self.base_ptr().cast::<MaybeUninit<T>>(), self.capacity)
+        }
+    }
+
+    /// Finalize this place, assuming all `self.len()` elements are initialized.
+    ///
+    /// Shrinks the allocation to fit, then returns the initialized slice.
+    ///
+    /// # Safety
+    ///
+    /// All `self.len()` elements must have been written (e.g. via
+    /// [`push`](EmplaceSlice::push) or manual writes to
+    /// [`as_uninit_mut`](EmplaceSlice::as_uninit_mut)).
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice::<u8>();
+    /// place.push(1);
+    /// place.push(2);
+    /// let s = unsafe { place.assume_init() };
+    /// assert_eq!(s, &[1, 2]);
+    /// ```
+    #[inline]
+    pub unsafe fn assume_init(mut self) -> &'a mut [T] {
+        self.shrink(self.len);
+        let len = self.len;
+        let ptr = self.base_ptr();
+        self.inner.guard.finish();
+        unsafe { slice::from_raw_parts_mut(ptr, len) }
+    }
+
+    /// Finalize this place, returning the full capacity as an exclusive slice
+    /// of `MaybeUninit<T>` without requiring initialization.
+    ///
+    /// The caller is responsible for ensuring that any positions they read from
+    /// the returned slice have been properly initialized.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let place = bump.emplace_slice_with_capacity::<u32>(4);
+    /// let uninit = place.into_uninit();
+    /// assert!(uninit.len() >= 4);
+    /// ```
+    #[inline]
+    pub fn into_uninit(self) -> &'a mut [MaybeUninit<T>] {
+        let cap = self.capacity;
+        let ptr = self.base_ptr().cast::<MaybeUninit<T>>();
+        self.inner.guard.finish();
+        unsafe { slice::from_raw_parts_mut(ptr, cap) }
+    }
+
+    /// Get the element capacity of this `[T]` place.
+    ///
+    /// This is the number of elements that can be held without reallocating.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let place = bump.emplace_slice_with_capacity::<u8>(4);
+    /// assert!(place.capacity() >= 4);
+    /// ```
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Get the number of initialized elements in this place.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice::<u8>();
+    /// assert_eq!(place.len(), 0);
+    /// place.push(1);
+    /// assert_eq!(place.len(), 1);
+    /// ```
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns `true` if no elements have been written.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice::<u8>();
+    /// assert!(place.is_empty());
+    /// place.push(1);
+    /// assert!(!place.is_empty());
+    /// ```
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Get the initialized elements as a shared slice.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice::<u8>();
+    /// place.push(1);
+    /// place.push(2);
+    /// assert_eq!(place.as_slice(), &[1, 2]);
+    /// ```
+    #[inline]
+    pub fn as_slice(&self) -> &[T] {
+        unsafe { slice::from_raw_parts(self.base_ptr(), self.len) }
+    }
+
+    /// Get the initialized elements as an exclusive slice.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice::<u8>();
+    /// place.push(10);
+    /// place.push(20);
+    /// place.as_mut_slice()[0] = 99;
+    /// assert_eq!(place.as_slice(), &[99, 20]);
+    /// ```
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        unsafe { slice::from_raw_parts_mut(self.base_ptr(), self.len) }
+    }
+
+    /// Finalize this place and return the initialized elements as a shared
+    /// slice.
+    ///
+    /// The allocation is shrunk to fit the initialized elements.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice::<u32>();
+    /// place.push(10);
+    /// place.push(20);
+    /// let s: &[u32] = place.into_slice();
+    /// assert_eq!(s, &[10, 20]);
+    /// ```
+    #[inline]
+    pub fn into_slice(self) -> &'a [T] {
+        self.into_mut_slice()
+    }
+
+    /// Finalize this place and return the initialized elements as an exclusive
+    /// slice.
+    ///
+    /// The allocation is shrunk to fit the initialized elements.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice::<u32>();
+    /// place.push(10);
+    /// place.push(20);
+    /// let s = place.into_mut_slice();
+    /// s[0] = 99;
+    /// assert_eq!(s, &[99, 20]);
+    /// ```
+    #[inline]
+    pub fn into_mut_slice(mut self) -> &'a mut [T] {
+        self.shrink(self.len);
+        let len = self.len;
+        let ptr = self.base_ptr();
+        self.inner.guard.finish();
+        unsafe { slice::from_raw_parts_mut(ptr, len) }
+    }
+
+    /// Shrink this place to the given new capacity.
+    ///
+    /// This is a no-op if `new_capacity >= self.capacity()`. The capacity will
+    /// never be reduced below `self.len()`.
+    ///
+    /// If shrinking fails (e.g. because this is not the last allocation), the
+    /// allocation is left as-is.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice_with_capacity::<u8>(16);
+    /// place.push(1);
+    /// place.push(2);
+    /// place.shrink(4);
+    /// assert!(place.capacity() <= 4);
+    /// ```
+    #[inline]
+    pub fn shrink(&mut self, new_capacity: usize) {
+        let _ = self.try_shrink(new_capacity);
+    }
+
+    /// Try to shrink this place to the given new capacity.
+    ///
+    /// This is a no-op if `new_capacity >= self.capacity()`. The capacity will
+    /// never be reduced below `self.len()`.
+    ///
+    /// ## Errors
+    ///
+    /// Returns an error if the underlying allocation cannot be shrunk.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # fn foo() -> Result<(), bumpalo::AllocErr> {
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice_with_capacity::<u8>(16);
+    /// place.push(1);
+    /// place.try_shrink(4)?;
+    /// assert!(place.capacity() <= 4);
+    /// # Ok(())
+    /// # }
+    /// # foo().unwrap();
+    /// ```
+    #[inline]
+    pub fn try_shrink(&mut self, new_capacity: usize) -> Result<(), AllocErr> {
+        if new_capacity >= self.capacity || mem::size_of::<T>() == 0 {
+            return Ok(());
+        }
+        debug_assert!(new_capacity >= self.len);
+        let new_capacity = new_capacity.max(self.len);
+
+        let old_layout = Layout::array::<T>(self.capacity).unwrap();
+        let new_layout = Layout::array::<T>(new_capacity).unwrap();
+
+        let ptr = self.inner.guard.ptr;
+        let new_ptr = unsafe { Bump::shrink(self.bump(), ptr, old_layout, new_layout)? };
+        self.inner.guard.ptr = new_ptr;
+        self.inner.ptr = new_ptr.cast();
+        self.capacity = new_capacity;
+        Ok(())
+    }
+
+    /// Shrink this place's capacity to exactly its length.
+    ///
+    /// If shrinking fails (e.g. because this is not the last allocation), the
+    /// allocation is left as-is.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice_with_capacity::<u8>(16);
+    /// place.push(1);
+    /// place.push(2);
+    /// place.shrink_to_fit();
+    /// assert!(place.capacity() <= 2);
+    /// ```
+    #[inline]
+    pub fn shrink_to_fit(&mut self) {
+        self.shrink(self.len);
+    }
+
+    /// Try to shrink this place's capacity to exactly its length.
+    ///
+    /// ## Errors
+    ///
+    /// Returns an error if the underlying allocation cannot be shrunk.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # fn foo() -> Result<(), bumpalo::AllocErr> {
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice_with_capacity::<u8>(16);
+    /// place.push(1);
+    /// place.try_shrink_to_fit()?;
+    /// assert!(place.capacity() <= 1);
+    /// # Ok(())
+    /// # }
+    /// # foo().unwrap();
+    /// ```
+    #[inline]
+    pub fn try_shrink_to_fit(&mut self) -> Result<(), AllocErr> {
+        self.try_shrink(self.len)
+    }
+
+    fn try_grow(&mut self, new_capacity: usize) -> Result<(), AllocErr> {
+        if new_capacity <= self.capacity {
+            return Ok(());
+        }
+
+        if mem::size_of::<T>() == 0 {
+            self.capacity = new_capacity;
+            return Ok(());
+        }
+
+        let old_layout = Layout::array::<T>(self.capacity).map_err(|_| AllocErr)?;
+        let new_layout = Layout::array::<T>(new_capacity).map_err(|_| AllocErr)?;
+
+        let ptr = self.inner.guard.ptr;
+        let new_ptr = unsafe { Bump::grow(self.bump(), ptr, old_layout, new_layout)? };
+
+        self.inner.guard.ptr = new_ptr;
+        self.inner.ptr = new_ptr.cast();
+        self.capacity = new_capacity;
+        Ok(())
+    }
+
+    /// Reserve capacity for at least `additional` more elements.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the allocation cannot be grown.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice::<u8>();
+    /// place.reserve(10);
+    /// assert!(place.capacity() >= 10);
+    /// ```
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        self.try_reserve(additional).unwrap_or_else(|_| oom())
+    }
+
+    /// Try to reserve capacity for at least `additional` more elements.
+    ///
+    /// Attempts to double capacity first; if that fails, falls back to
+    /// reserving exactly the amount needed.
+    ///
+    /// ## Errors
+    ///
+    /// Returns an error if the allocation cannot be grown.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # fn foo() -> Result<(), bumpalo::AllocErr> {
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice::<u8>();
+    /// place.try_reserve(10)?;
+    /// assert!(place.capacity() >= 10);
+    /// # Ok(())
+    /// # }
+    /// # foo().unwrap();
+    /// ```
+    #[inline]
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), AllocErr> {
+        let needed = self.len.checked_add(additional).ok_or(AllocErr)?;
+        if needed <= self.capacity {
+            return Ok(());
+        }
+
+        // Try doubling first.
+        let doubled = self.capacity.saturating_mul(2).max(needed);
+        if self.try_grow(doubled).is_ok() {
+            return Ok(());
+        }
+
+        // Fall back to exactly what's needed.
+        self.try_grow(needed)
+    }
+
+    /// Reserve capacity for exactly `additional` more elements.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the allocation cannot be grown.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice::<u8>();
+    /// place.reserve_exact(5);
+    /// assert!(place.capacity() >= 5);
+    /// ```
+    #[inline]
+    pub fn reserve_exact(&mut self, additional: usize) {
+        self.try_reserve_exact(additional).unwrap_or_else(|_| oom())
+    }
+
+    /// Try to reserve capacity for exactly `additional` more elements.
+    ///
+    /// ## Errors
+    ///
+    /// Returns an error if the allocation cannot be grown.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # fn foo() -> Result<(), bumpalo::AllocErr> {
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice::<u8>();
+    /// place.try_reserve_exact(5)?;
+    /// assert!(place.capacity() >= 5);
+    /// # Ok(())
+    /// # }
+    /// # foo().unwrap();
+    /// ```
+    #[inline]
+    pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), AllocErr> {
+        let needed = self.len.checked_add(additional).ok_or(AllocErr)?;
+        self.try_grow(needed)
+    }
+
+    /// Push an element onto this place, growing if necessary.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the place is at capacity and growing the allocation fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice::<u8>();
+    /// place.push(1);
+    /// place.push(2);
+    /// assert_eq!(place.as_slice(), &[1, 2]);
+    /// ```
+    #[inline]
+    pub fn push(&mut self, element: T) {
+        self.try_push(element).unwrap_or_else(|_| oom())
+    }
+
+    /// Try to push an element, growing if necessary.
+    ///
+    /// Returns `Err(element)` if the place is at capacity and growing fails,
+    /// giving back ownership of the element.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice::<u8>();
+    /// assert!(place.try_push(42).is_ok());
+    /// assert_eq!(place.as_slice(), &[42]);
+    /// ```
+    #[inline]
+    pub fn try_push(&mut self, element: T) -> Result<(), T> {
+        debug_assert!(self.len <= self.capacity);
+        if self.len == self.capacity {
+            if self.try_reserve(1).is_err() {
+                return Err(element);
+            }
+        }
+        unsafe {
+            ptr::write(self.base_ptr().add(self.len), element);
+        }
+        self.len += 1;
+        Ok(())
+    }
+
+    /// Extend this place with elements from an iterator, growing as needed.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if growing the allocation fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice::<u8>();
+    /// place.extend(0..5);
+    /// assert_eq!(place.as_slice(), &[0, 1, 2, 3, 4]);
+    /// ```
+    #[inline]
+    pub fn extend(&mut self, iter: impl IntoIterator<Item = T>) {
+        for element in iter {
+            self.push(element);
+        }
+    }
+
+    /// Try to extend this place with elements from an iterator, growing as
+    /// needed.
+    ///
+    /// ## Errors
+    ///
+    /// Returns an error if growing the allocation fails. Elements already
+    /// pushed before the failure remain in the place.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # fn foo() -> Result<(), bumpalo::AllocErr> {
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice::<u8>();
+    /// place.try_extend(0..3)?;
+    /// assert_eq!(place.as_slice(), &[0, 1, 2]);
+    /// # Ok(())
+    /// # }
+    /// # foo().unwrap();
+    /// ```
+    #[inline]
+    pub fn try_extend(&mut self, iter: impl IntoIterator<Item = T>) -> Result<(), AllocErr> {
+        let iter = iter.into_iter();
+        let (min, max) = iter.size_hint();
+        self.try_reserve(max.unwrap_or(min))?;
+        for element in iter {
+            if self.try_push(element).is_err() {
+                return Err(AllocErr);
+            }
+        }
+        Ok(())
+    }
+
+    /// Extend this place by copying elements from a slice.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if growing the allocation fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice::<u8>();
+    /// place.extend_from_slice_copy(&[1, 2, 3]);
+    /// assert_eq!(place.as_slice(), &[1, 2, 3]);
+    /// ```
+    #[inline]
+    pub fn extend_from_slice_copy(&mut self, src: &[T])
+    where
+        T: Copy,
+    {
+        self.try_extend_from_slice_copy(src)
+            .unwrap_or_else(|_| oom())
+    }
+
+    /// Try to extend this place by copying elements from a slice.
+    ///
+    /// ## Errors
+    ///
+    /// Returns an error if growing the allocation fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # fn foo() -> Result<(), bumpalo::AllocErr> {
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice::<u8>();
+    /// place.try_extend_from_slice_copy(&[1, 2, 3])?;
+    /// assert_eq!(place.as_slice(), &[1, 2, 3]);
+    /// # Ok(())
+    /// # }
+    /// # foo().unwrap();
+    /// ```
+    #[inline]
+    pub fn try_extend_from_slice_copy(&mut self, src: &[T]) -> Result<(), AllocErr>
+    where
+        T: Copy,
+    {
+        self.try_reserve_exact(src.len())?;
+        unsafe {
+            ptr::copy_nonoverlapping(src.as_ptr(), self.base_ptr().add(self.len), src.len());
+        }
+        self.len += src.len();
+        Ok(())
+    }
+
+    /// Extend this place by cloning elements from a slice.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if growing the allocation fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice::<u8>();
+    /// place.extend_from_slice_clone(&[1, 2, 3]);
+    /// assert_eq!(place.as_slice(), &[1, 2, 3]);
+    /// ```
+    #[inline]
+    pub fn extend_from_slice_clone(&mut self, src: &[T])
+    where
+        T: Clone,
+    {
+        self.try_extend_from_slice_clone(src)
+            .unwrap_or_else(|_| oom())
+    }
+
+    /// Try to extend this place by cloning elements from a slice.
+    ///
+    /// ## Errors
+    ///
+    /// Returns an error if growing the allocation fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # fn foo() -> Result<(), bumpalo::AllocErr> {
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice::<u8>();
+    /// place.try_extend_from_slice_clone(&[1, 2, 3])?;
+    /// assert_eq!(place.as_slice(), &[1, 2, 3]);
+    /// # Ok(())
+    /// # }
+    /// # foo().unwrap();
+    /// ```
+    #[inline]
+    pub fn try_extend_from_slice_clone(&mut self, src: &[T]) -> Result<(), AllocErr>
+    where
+        T: Clone,
+    {
+        self.try_reserve_exact(src.len())?;
+        for val in src.iter().cloned() {
+            unsafe {
+                ptr::write(self.base_ptr().add(self.len), val);
+            }
+            self.len += 1;
+        }
+        Ok(())
+    }
+
+    /// Consume an iterator, push all elements, shrink to fit, and finalize.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if growing the allocation fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let place = bump.emplace_slice::<u8>();
+    /// let s = place.write_iter(0..5);
+    /// assert_eq!(s, &[0, 1, 2, 3, 4]);
+    /// ```
+    #[inline]
+    pub fn write_iter(mut self, iter: impl IntoIterator<Item = T>) -> &'a mut [T] {
+        self.extend(iter);
+        self.into_mut_slice()
+    }
+
+    /// Try to consume an iterator, push all elements, shrink to fit, and
+    /// finalize.
+    ///
+    /// ## Errors
+    ///
+    /// Returns an error if growing the allocation fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # fn foo() -> Result<(), bumpalo::AllocErr> {
+    /// let bump = bumpalo::Bump::new();
+    /// let place = bump.emplace_slice::<u8>();
+    /// let s = place.try_write_iter(0..5)?;
+    /// assert_eq!(s, &[0, 1, 2, 3, 4]);
+    /// # Ok(())
+    /// # }
+    /// # foo().unwrap();
+    /// ```
+    #[inline]
+    pub fn try_write_iter(
+        mut self,
+        iter: impl IntoIterator<Item = T>,
+    ) -> Result<&'a mut [T], AllocErr> {
+        self.try_extend(iter)?;
+        Ok(self.into_mut_slice())
+    }
+
+    /// Copy a slice into this place, growing if necessary, and finalize.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if growing the allocation fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let data = [1u8, 2, 3, 4];
+    /// let s = bump.emplace_slice_with_capacity(data.len()).copy_slice(&data);
+    /// assert_eq!(s, &[1, 2, 3, 4]);
+    /// ```
+    #[inline]
+    pub fn copy_slice(self, from: &[T]) -> &'a mut [T]
+    where
+        T: Copy,
+    {
+        self.try_copy_slice(from).unwrap_or_else(|_| oom())
+    }
+
+    /// Try to copy a slice into this place, growing if necessary, and
+    /// finalize.
+    ///
+    /// ## Errors
+    ///
+    /// Returns an error if growing the allocation fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # fn foo() -> Result<(), bumpalo::AllocErr> {
+    /// let bump = bumpalo::Bump::new();
+    /// let data = [1u8, 2, 3];
+    /// let s = bump.emplace_slice_with_capacity(data.len()).try_copy_slice(&data)?;
+    /// assert_eq!(s, &[1, 2, 3]);
+    /// # Ok(())
+    /// # }
+    /// # foo().unwrap();
+    /// ```
+    #[inline]
+    pub fn try_copy_slice(mut self, from: &[T]) -> Result<&'a mut [T], AllocErr>
+    where
+        T: Copy,
+    {
+        self.try_reserve_exact(from.len().saturating_sub(self.capacity))?;
+        unsafe {
+            ptr::copy_nonoverlapping(from.as_ptr(), self.base_ptr(), from.len());
+        }
+        self.len = from.len();
+        Ok(self.into_mut_slice())
+    }
+
+    /// Clone a slice into this place, growing if necessary, and finalize.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if growing the allocation fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let data = [1u8, 2, 3];
+    /// let s = bump.emplace_slice_with_capacity(data.len()).clone_slice(&data);
+    /// assert_eq!(s, &[1, 2, 3]);
+    /// ```
+    #[inline]
+    pub fn clone_slice(self, from: &[T]) -> &'a mut [T]
+    where
+        T: Clone,
+    {
+        self.try_clone_slice(from).unwrap_or_else(|_| oom())
+    }
+
+    /// Try to clone a slice into this place, growing if necessary, and
+    /// finalize.
+    ///
+    /// ## Errors
+    ///
+    /// Returns an error if growing the allocation fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # fn foo() -> Result<(), bumpalo::AllocErr> {
+    /// let bump = bumpalo::Bump::new();
+    /// let data = [1u8, 2, 3];
+    /// let s = bump.emplace_slice_with_capacity(data.len()).try_clone_slice(&data)?;
+    /// assert_eq!(s, &[1, 2, 3]);
+    /// # Ok(())
+    /// # }
+    /// # foo().unwrap();
+    /// ```
+    #[inline]
+    pub fn try_clone_slice(mut self, from: &[T]) -> Result<&'a mut [T], AllocErr>
+    where
+        T: Clone,
+    {
+        self.try_reserve_exact(from.len().saturating_sub(self.capacity))?;
+        for (i, val) in from.iter().cloned().enumerate() {
+            unsafe {
+                ptr::write(self.base_ptr().add(i), val);
+            }
+        }
+        self.len = from.len();
+        Ok(self.into_mut_slice())
+    }
+}
+
+/// An in-place allocation builder for UTF-8 string slices.
+///
+/// Created by [`Bump::emplace_str`], [`Bump::emplace_str_with_capacity`], or
+/// their `try_*` variants.
+///
+/// ## Example
+///
+/// ```
+/// let bump = bumpalo::Bump::new();
+/// let mut place = bump.emplace_str();
+/// place.push_str("hello, ");
+/// place.push_str("world!");
+/// let s = place.into_str();
+/// assert_eq!(s, "hello, world!");
+/// ```
+#[derive(Debug)]
+pub struct EmplaceStr<'a, const MIN_ALIGN: usize> {
+    inner: EmplaceSlice<'a, u8, MIN_ALIGN>,
+}
+
+impl<'a, const MIN_ALIGN: usize> EmplaceStr<'a, MIN_ALIGN> {
+    pub(crate) unsafe fn new(inner: EmplaceSlice<'a, u8, MIN_ALIGN>) -> Self {
+        Self { inner }
+    }
+
+    /// Get the number of bytes written into this place thus far.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_str();
+    /// assert_eq!(place.len(), 0);
+    /// place.push_str("hi");
+    /// assert_eq!(place.len(), 2);
+    /// ```
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns `true` if no bytes have been written.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_str();
+    /// assert!(place.is_empty());
+    /// place.push('a');
+    /// assert!(!place.is_empty());
+    /// ```
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Get the byte capacity of this string place.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let place = bump.emplace_str_with_capacity(16);
+    /// assert!(place.capacity() >= 16);
+    /// ```
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity()
+    }
+
+    /// View the initialized portion as a string slice.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_str();
+    /// place.push_str("hello");
+    /// assert_eq!(place.as_str(), "hello");
+    /// ```
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        unsafe { str::from_utf8_unchecked(self.inner.as_slice()) }
+    }
+
+    /// View the initialized portion as a mutable string slice.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_str();
+    /// place.push_str("hello");
+    /// place.as_str_mut().make_ascii_uppercase();
+    /// assert_eq!(place.as_str(), "HELLO");
+    /// ```
+    #[inline]
+    pub fn as_str_mut(&mut self) -> &mut str {
+        unsafe { str::from_utf8_unchecked_mut(self.inner.as_mut_slice()) }
+    }
+
+    /// Append a string slice to this place.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if growing the allocation fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_str();
+    /// place.push_str("hello");
+    /// place.push_str(" world");
+    /// assert_eq!(place.as_str(), "hello world");
+    /// ```
+    #[inline]
+    pub fn push_str(&mut self, s: &str) {
+        self.try_push_str(s).unwrap_or_else(|_| oom())
+    }
+
+    /// Try to append a string slice to this place.
+    ///
+    /// ## Errors
+    ///
+    /// Returns an error if growing the allocation fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # fn foo() -> Result<(), bumpalo::AllocErr> {
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_str();
+    /// place.try_push_str("hello")?;
+    /// assert_eq!(place.as_str(), "hello");
+    /// # Ok(())
+    /// # }
+    /// # foo().unwrap();
+    /// ```
+    #[inline]
+    pub fn try_push_str(&mut self, s: &str) -> Result<(), AllocErr> {
+        self.inner.try_extend_from_slice_copy(s.as_bytes())
+    }
+
+    /// Append a character to this place (encoded as UTF-8).
+    ///
+    /// ## Panics
+    ///
+    /// Panics if growing the allocation fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_str();
+    /// place.push('h');
+    /// place.push('i');
+    /// assert_eq!(place.as_str(), "hi");
+    /// ```
+    #[inline]
+    pub fn push(&mut self, c: char) {
+        self.try_push(c).unwrap_or_else(|_| oom())
+    }
+
+    /// Try to append a character to this place (encoded as UTF-8).
+    ///
+    /// ## Errors
+    ///
+    /// Returns an error if growing the allocation fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # fn foo() -> Result<(), bumpalo::AllocErr> {
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_str();
+    /// place.try_push('h')?;
+    /// place.try_push('i')?;
+    /// assert_eq!(place.as_str(), "hi");
+    /// # Ok(())
+    /// # }
+    /// # foo().unwrap();
+    /// ```
+    #[inline]
+    pub fn try_push(&mut self, c: char) -> Result<(), AllocErr> {
+        let mut buf = [0u8; 4];
+        let s = c.encode_utf8(&mut buf);
+        self.try_push_str(s)
+    }
+
+    /// Write a string into this place and finalize.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if growing the allocation fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let s = bump.emplace_str_with_capacity(5).write_str("hello");
+    /// assert_eq!(s, "hello");
+    /// ```
+    #[inline]
+    pub fn write_str(mut self, s: &str) -> &'a mut str {
+        self.push_str(s);
+        self.into_str_mut()
+    }
+
+    /// Try to write a string into this place and finalize.
+    ///
+    /// ## Errors
+    ///
+    /// Returns an error if growing the allocation fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # fn foo() -> Result<(), bumpalo::AllocErr> {
+    /// let bump = bumpalo::Bump::new();
+    /// let s = bump.emplace_str_with_capacity(5).try_write_str("hello")?;
+    /// assert_eq!(s, "hello");
+    /// # Ok(())
+    /// # }
+    /// # foo().unwrap();
+    /// ```
+    #[inline]
+    pub fn try_write_str(mut self, s: &str) -> Result<&'a mut str, AllocErr> {
+        self.try_push_str(s)?;
+        Ok(self.into_str_mut())
+    }
+
+    /// Finalize this place, returning the initialized portion as `&str`.
+    ///
+    /// The allocation is shrunk to fit.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_str();
+    /// place.push_str("hello");
+    /// let s: &str = place.into_str();
+    /// assert_eq!(s, "hello");
+    /// ```
+    #[inline]
+    pub fn into_str(self) -> &'a str {
+        self.into_str_mut()
+    }
+
+    /// Finalize this place, returning the initialized portion as `&mut str`.
+    ///
+    /// The allocation is shrunk to fit.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_str();
+    /// place.push_str("hello");
+    /// let s: &mut str = place.into_str_mut();
+    /// s.make_ascii_uppercase();
+    /// assert_eq!(s, "HELLO");
+    /// ```
+    #[inline]
+    pub fn into_str_mut(self) -> &'a mut str {
+        let slice = self.inner.into_mut_slice();
+        unsafe { str::from_utf8_unchecked_mut(slice) }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod boxed;
 pub mod collections;
 
 mod alloc;
+mod emplace;
 
 use core::cell::Cell;
 use core::cmp::Ordering;
@@ -32,6 +33,7 @@ use core_alloc::alloc::{AllocError, Allocator};
 use allocator_api2::alloc::{AllocError, Allocator};
 
 pub use alloc::AllocErr;
+pub use emplace::{Emplace, EmplaceSlice, EmplaceStr};
 
 /// An error returned from [`Bump::try_alloc_try_with`].
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -223,149 +225,141 @@ impl<const MIN_ALIGN: usize> Drop for RewindGuard<'_, MIN_ALIGN> {
 /// *s = "the bump allocator; and also is a buffalo";
 /// ```
 ///
-/// ## Allocation Methods Come in Many Flavors
+/// ## The `Emplace` API
 ///
-/// There are various allocation methods on `Bump`, the simplest being
-/// [`alloc`][Bump::alloc]. The others exist to satisfy some combination of
-/// fallible allocation and initialization. The allocation methods are
-/// summarized in the following table:
-///
-/// <table>
-///   <thead>
-///     <tr>
-///       <th></th>
-///       <th>Infallible Allocation</th>
-///       <th>Fallible Allocation</th>
-///     </tr>
-///   </thead>
-///     <tr>
-///       <th>By Value</th>
-///       <td><a href="#method.alloc"><code>alloc</code></a></td>
-///       <td><a href="#method.try_alloc"><code>try_alloc</code></a></td>
-///     </tr>
-///     <tr>
-///       <th>Infallible Initializer Function</th>
-///       <td><a href="#method.alloc_with"><code>alloc_with</code></a></td>
-///       <td><a href="#method.try_alloc_with"><code>try_alloc_with</code></a></td>
-///     </tr>
-///     <tr>
-///       <th>Fallible Initializer Function</th>
-///       <td><a href="#method.alloc_try_with"><code>alloc_try_with</code></a></td>
-///       <td><a href="#method.try_alloc_try_with"><code>try_alloc_try_with</code></a></td>
-///     </tr>
-///   <tbody>
-///   </tbody>
-/// </table>
-///
-/// ### Fallible Allocation: The `try_alloc_` Method Prefix
-///
-/// These allocation methods let you recover from out-of-memory (OOM)
-/// scenarios, rather than raising a panic on OOM.
+/// `Bump` has a number of "emplace" methods that separate allocation from
+/// initialization. This is useful in certain edge-cases related to compiler
+/// optimizations. For example, `bump.alloc(x)` is semantically creating `x` on
+/// the stack, and then allocating space within `bump` for it, and then moving
+/// it into that space. However, the sequence we want is for the space to be
+/// allocated in `bump` and then for `x` constructed directly in that allocated
+/// space. Sometimes the compiler can do that for us. But in many cases, it does
+/// not or cannot. The "emplace" methods let us make the desired sequencing
+/// explicit and subsequently allows the compiler to optimize the code such that
+/// it constructs `x` directly inside the allocated space in many more cases.
 ///
 /// ```
 /// use bumpalo::Bump;
 ///
 /// let bump = Bump::new();
 ///
-/// match bump.try_alloc(MyStruct {
-///     // ...
-/// }) {
-///     Ok(my_struct) => {
-///         // Allocation succeeded.
-///     }
-///     Err(e) => {
-///         // Out of memory.
-///     }
-/// }
+/// let x = bump
+///     // Pre-allocate space for the value.
+///     .emplace()
+///     // Write the value into the pre-allocated space.
+///     .write(42);
 ///
-/// struct MyStruct {
-///     // ...
-/// }
+/// assert_eq!(*x, 42);
 /// ```
 ///
-/// ### Initializer Functions: The `_with` Method Suffix
+/// Furthermore, the emplace methods play nicer with fallible initialization and
+/// `?`-propagation. For example, if you are constructing a slice in a `Bump`
+/// but each item's construction is also fallible:
 ///
-/// Calling one of the generic `…alloc(x)` methods is essentially equivalent to
-/// the matching [`…alloc_with(|| x)`](?search=alloc_with). However if you use
-/// `…alloc_with`, then the closure will not be invoked until after allocating
-/// space for storing `x` on the heap.
+/// ```
+/// # fn foo() -> Result<(), ()> {
+/// use bumpalo::Bump;
 ///
-/// This can be useful in certain edge-cases related to compiler optimizations.
-/// When evaluating for example `bump.alloc(x)`, semantically `x` is first put
-/// on the stack and then moved onto the heap. In some cases, the compiler is
-/// able to optimize this into constructing `x` directly on the heap, however
-/// in many cases it does not.
+/// let bump = Bump::new();
 ///
-/// The `…alloc_with` functions try to help the compiler be smarter. In most
-/// cases doing for example `bump.try_alloc_with(|| x)` on release mode will be
-/// enough to help the compiler realize that this optimization is valid and
-/// to construct `x` directly onto the heap.
+/// // Pre-allocate space for a slice in `bump`.
+/// let mut place = bump.emplace_slice_with_capacity(10);
+/// # let my_fallible_collection = || Vec::<Result<u32, ()>>::new();
 ///
-/// #### Warning
+/// // Iterate over `Result`s, propagating errors with `?`, and pushing the
+/// // items into place.
+/// for result in my_fallible_collection() {
+///     let item = result?;
+///     place.push(item);
+/// }
 ///
-/// These functions critically depend on compiler optimizations to achieve their
-/// desired effect. This means that it is not an effective tool when compiling
-/// without optimizations on.
-///
-/// Even when optimizations are on, these functions do not **guarantee** that
-/// the value is constructed on the heap. To the best of our knowledge no such
-/// guarantee can be made in stable Rust as of 1.54.
-///
-/// ### Fallible Initialization: The `_try_with` Method Suffix
-///
-/// The generic [`…alloc_try_with(|| x)`](?search=_try_with) methods behave
-/// like the purely `_with` suffixed methods explained above. However, they
-/// allow for fallible initialization by accepting a closure that returns a
-/// [`Result`] and will attempt to undo the initial allocation if this closure
-/// returns [`Err`].
-///
-/// #### Warning
-///
-/// If the inner closure returns [`Ok`], space for the entire [`Result`] remains
-/// allocated inside `self`. This can be a problem especially if the [`Err`]
-/// variant is larger, but even otherwise there may be overhead for the
-/// [`Result`]'s discriminant.
-///
-/// <p><details><summary>Undoing the allocation in the <code>Err</code> case
-/// always fails if <code>f</code> successfully made any additional allocations
-/// in <code>self</code>.</summary>
-///
-/// For example, the following will always leak also space for the [`Result`]
-/// into this `Bump`, even though the inner reference isn't kept and the [`Err`]
-/// payload is returned semantically by value:
-///
-/// ```rust
-/// let bump = bumpalo::Bump::new();
-///
-/// let r: Result<&mut [u8; 1000], ()> = bump.alloc_try_with(|| {
-///     let _ = bump.alloc(0_u8);
-///     Err(())
-/// });
-///
-/// assert!(r.is_err());
+/// // After all the items have been pushed, we can get the initialized slice.
+/// let slice = place.into_slice();
+/// # Ok(())
+/// # }
+/// # foo().unwrap();
 /// ```
 ///
-///</details></p>
+/// See also each emplace method:
 ///
-/// Since [`Err`] payloads are first placed on the heap and then moved to the
-/// stack, `bump.…alloc_try_with(|| x)?` is likely to execute more slowly than
-/// the matching `bump.…alloc(x?)` in case of initialization failure. If this
-/// happens frequently, using the plain un-suffixed method may perform better.
+/// * [`Bump::emplace`]
+/// * [`Bump::emplace_slice`]
+/// * [`Bump::emplace_slice_with_capacity`]
+/// * [`Bump::emplace_str`]
+/// * [`Bump::emplace_str_with_capacity`]
+/// * [`Bump::try_emplace`]
+/// * [`Bump::try_emplace_slice`]
+/// * [`Bump::try_emplace_slice_with_capacity`]
+/// * [`Bump::try_emplace_str`]
+/// * [`Bump::try_emplace_str_with_capacity`]
 ///
-/// [`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html
-/// [`Ok`]: https://doc.rust-lang.org/std/result/enum.Result.html#variant.Ok
-/// [`Err`]: https://doc.rust-lang.org/std/result/enum.Result.html#variant.Err
+/// See also the `Emplace*` types, returned from those methods:
 ///
-/// ### `Bump` Allocation Limits
+/// * [`Emplace`]
+/// * [`EmplaceSlice`]
+/// * [`EmplaceStr`]
+///
+/// ## Allocation Helper Methods
+///
+/// There are various allocation methods on `Bump`, for a variety of
+/// combinations of (in)fallible allocation and initialization. These methods
+/// are all built on top of the emplace APIs, and often using the emplace APIs
+/// is cleaner, but sometimes it is nice to have a single method that does
+/// everything at once.
+///
+/// The allocation helper methods, and their equivalent emplace calls, are
+/// summarized in the following table:
+///
+/// <table>
+///   <thead>
+///     <tr>
+///       <th></th>
+///       <th colspan="2">Infallible Allocation</th>
+///       <th colspan="2">Fallible Allocation</th>
+///     </tr>
+///     <tr>
+///       <th></th>
+///       <th><code>Emplace</code> API</th>
+///       <th><code>*alloc*</code> Method</th>
+///       <th><code>Emplace</code> API</th>
+///       <th><code>*alloc*</code> Method</th>
+///     </tr>
+///   </thead>
+///   <tbody>
+///     <tr>
+///       <th>By Value</th>
+///       <td><code>bump.emplace().write(value)</code></td>
+///       <td><a href="#method.alloc"><code>alloc</code></a></td>
+///       <td><code>bump.try_emplace()?.write(value)</code></td>
+///       <td><a href="#method.try_alloc"><code>try_alloc</code></a></td>
+///     </tr>
+///     <tr>
+///       <th>Infallible Initializer Function</th>
+///       <td><code>bump.emplace().write(f())</code></td>
+///       <td><a href="#method.alloc_with"><code>alloc_with</code></a></td>
+///       <td><code>bump.try_emplace()?.write(f())</code></td>
+///       <td><a href="#method.try_alloc_with"><code>try_alloc_with</code></a></td>
+///     </tr>
+///     <tr>
+///       <th>Fallible Initializer Function</th>
+///       <td><code>bump.emplace().write(f()?)</code></td>
+///       <td><a href="#method.alloc_try_with"><code>alloc_try_with</code></a></td>
+///       <td><code>bump.try_emplace()?.write(f()?)</code></td>
+///       <td><a href="#method.try_alloc_try_with"><code>try_alloc_try_with</code></a></td>
+///     </tr>
+///   <tbody>
+///   </tbody>
+/// </table>
+///
+/// ## `Bump` Allocation Limits
 ///
 /// `bumpalo` supports setting a limit on the maximum bytes of memory that can
-/// be allocated for use in a particular `Bump` arena. This limit can be set and removed with
-/// [`set_allocation_limit`][Bump::set_allocation_limit].
+/// be allocated for use in a particular `Bump` arena. This limit can be set and
+/// removed with [`set_allocation_limit`][Bump::set_allocation_limit].
+///
 /// The allocation limit is only enforced when allocating new backing chunks for
 /// a `Bump`. Updating the allocation limit will not affect existing allocations
 /// or any future allocations within the `Bump`'s current chunk.
-///
-/// #### Example
 ///
 /// ```
 /// let bump = bumpalo::Bump::new();
@@ -376,19 +370,11 @@ impl<const MIN_ALIGN: usize> Drop for RewindGuard<'_, MIN_ALIGN> {
 /// assert!(bump.try_alloc(5).is_err());
 ///
 /// bump.set_allocation_limit(Some(6));
-///
 /// assert_eq!(bump.allocation_limit(), Some(6));
 ///
 /// bump.set_allocation_limit(None);
-///
 /// assert_eq!(bump.allocation_limit(), None);
 /// ```
-///
-/// #### Warning
-///
-/// Because of backwards compatibility, allocations that fail
-/// due to allocation limits will not present differently than
-/// errors due to resource exhaustion.
 #[derive(Debug)]
 pub struct Bump<const MIN_ALIGN: usize = 1> {
     // The current chunk we are bump allocating within.
@@ -1112,8 +1098,11 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         }
     }
 
-    /// Allocate an object in this `Bump` and return an exclusive reference to
-    /// it.
+    /// Allocate space for a `T` and return an [`Emplace`] builder.
+    ///
+    /// The returned builder lets you initialize the value in place. If
+    /// the builder is dropped without being finalized, the allocation is
+    /// automatically reclaimed.
     ///
     /// ## Panics
     ///
@@ -1123,735 +1112,185 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     ///
     /// ```
     /// let bump = bumpalo::Bump::new();
-    /// let x = bump.alloc("hello");
-    /// assert_eq!(*x, "hello");
+    /// let x = bump.emplace().write(42u64);
+    /// assert_eq!(*x, 42);
     /// ```
     #[inline(always)]
-    pub fn alloc<T>(&self, val: T) -> &mut T {
-        self.alloc_with(|| val)
+    pub fn emplace<T>(&self) -> Emplace<'_, T, MIN_ALIGN> {
+        self.try_emplace().unwrap_or_else(|_| oom())
     }
 
-    /// Try to allocate an object in this `Bump` and return an exclusive
-    /// reference to it.
+    /// Try to allocate space for a `T` and return an [`Emplace`] builder.
     ///
     /// ## Errors
     ///
-    /// Errors if reserving space for `T` fails.
+    /// Returns an error if reserving space for `T` fails.
     ///
     /// ## Example
     ///
     /// ```
+    /// # fn foo() -> Result<(), bumpalo::AllocErr> {
     /// let bump = bumpalo::Bump::new();
-    /// let x = bump.try_alloc("hello");
-    /// assert_eq!(x, Ok(&mut "hello"));
+    /// let x = bump.try_emplace::<u64>()?.write(42);
+    /// assert_eq!(*x, 42);
+    /// # Ok(())
+    /// # }
+    /// # foo().unwrap();
     /// ```
     #[inline(always)]
-    pub fn try_alloc<T>(&self, val: T) -> Result<&mut T, AllocErr> {
-        self.try_alloc_with(|| val)
-    }
-
-    /// Pre-allocate space for an object in this `Bump`, initializes it using
-    /// the closure, then returns an exclusive reference to it.
-    ///
-    /// See [The `_with` Method Suffix](#initializer-functions-the-_with-method-suffix) for a
-    /// discussion on the differences between the `_with` suffixed methods and
-    /// those methods without it, their performance characteristics, and when
-    /// you might or might not choose a `_with` suffixed method.
-    ///
-    /// ## Panics
-    ///
-    /// Panics if reserving space for `T` fails.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// let bump = bumpalo::Bump::new();
-    /// let x = bump.alloc_with(|| "hello");
-    /// assert_eq!(*x, "hello");
-    /// ```
-    #[inline(always)]
-    pub fn alloc_with<F, T>(&self, f: F) -> &mut T
-    where
-        F: FnOnce() -> T,
-    {
-        #[inline(always)]
-        unsafe fn inner_writer<T, F>(ptr: *mut T, f: F)
-        where
-            F: FnOnce() -> T,
-        {
-            // This function is translated as:
-            // - allocate space for a T on the stack
-            // - call f() with the return value being put onto this stack space
-            // - memcpy from the stack to the heap
-            //
-            // Ideally we want LLVM to always realize that doing a stack
-            // allocation is unnecessary and optimize the code so it writes
-            // directly into the heap instead. It seems we get it to realize
-            // this most consistently if we put this critical line into it's
-            // own function instead of inlining it into the surrounding code.
-            ptr::write(ptr, f());
-        }
-
+    pub fn try_emplace<T>(&self) -> Result<Emplace<'_, T, MIN_ALIGN>, AllocErr> {
         let layout = Layout::new::<T>();
-
-        unsafe {
-            let p = self.alloc_layout(layout);
-            let p = p.as_ptr() as *mut T;
-            inner_writer(p, f);
-            &mut *p
-        }
-    }
-
-    /// Tries to pre-allocate space for an object in this `Bump`, initializes
-    /// it using the closure, then returns an exclusive reference to it.
-    ///
-    /// See [The `_with` Method Suffix](#initializer-functions-the-_with-method-suffix) for a
-    /// discussion on the differences between the `_with` suffixed methods and
-    /// those methods without it, their performance characteristics, and when
-    /// you might or might not choose a `_with` suffixed method.
-    ///
-    /// ## Errors
-    ///
-    /// Errors if reserving space for `T` fails.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// let bump = bumpalo::Bump::new();
-    /// let x = bump.try_alloc_with(|| "hello");
-    /// assert_eq!(x, Ok(&mut "hello"));
-    /// ```
-    #[inline(always)]
-    pub fn try_alloc_with<F, T>(&self, f: F) -> Result<&mut T, AllocErr>
-    where
-        F: FnOnce() -> T,
-    {
-        #[inline(always)]
-        unsafe fn inner_writer<T, F>(ptr: *mut T, f: F)
-        where
-            F: FnOnce() -> T,
-        {
-            // This function is translated as:
-            // - allocate space for a T on the stack
-            // - call f() with the return value being put onto this stack space
-            // - memcpy from the stack to the heap
-            //
-            // Ideally we want LLVM to always realize that doing a stack
-            // allocation is unnecessary and optimize the code so it writes
-            // directly into the heap instead. It seems we get it to realize
-            // this most consistently if we put this critical line into it's
-            // own function instead of inlining it into the surrounding code.
-            ptr::write(ptr, f());
-        }
-
-        //SAFETY: Self-contained:
-        // `p` is allocated for `T` and then a `T` is written.
-        let layout = Layout::new::<T>();
-        let p = self.try_alloc_layout(layout)?;
-        let p = p.as_ptr() as *mut T;
-
-        unsafe {
-            inner_writer(p, f);
-            Ok(&mut *p)
-        }
-    }
-
-    /// Pre-allocates space for a [`Result`] in this `Bump`, initializes it using
-    /// the closure, then returns an exclusive reference to its `T` if [`Ok`].
-    ///
-    /// Iff the allocation fails, the closure is not run.
-    ///
-    /// Iff [`Err`], an allocator rewind is *attempted* and the `E` instance is
-    /// moved out of the allocator to be consumed or dropped as normal.
-    ///
-    /// See [The `_with` Method Suffix](#initializer-functions-the-_with-method-suffix) for a
-    /// discussion on the differences between the `_with` suffixed methods and
-    /// those methods without it, their performance characteristics, and when
-    /// you might or might not choose a `_with` suffixed method.
-    ///
-    /// For caveats specific to fallible initialization, see
-    /// [The `_try_with` Method Suffix](#fallible-initialization-the-_try_with-method-suffix).
-    ///
-    /// [`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html
-    /// [`Ok`]: https://doc.rust-lang.org/std/result/enum.Result.html#variant.Ok
-    /// [`Err`]: https://doc.rust-lang.org/std/result/enum.Result.html#variant.Err
-    ///
-    /// ## Errors
-    ///
-    /// Iff the allocation succeeds but `f` fails, that error is forwarded by value.
-    ///
-    /// ## Panics
-    ///
-    /// Panics if reserving space for `Result<T, E>` fails.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// let bump = bumpalo::Bump::new();
-    /// let x = bump.alloc_try_with(|| Ok("hello"))?;
-    /// assert_eq!(*x, "hello");
-    /// # Result::<_, ()>::Ok(())
-    /// ```
-    #[inline(always)]
-    pub fn alloc_try_with<F, T, E>(&self, f: F) -> Result<&mut T, E>
-    where
-        F: FnOnce() -> Result<T, E>,
-    {
-        match self.try_alloc_try_with(f) {
-            Ok(x) => Ok(x),
-            Err(AllocOrInitError::Init(e)) => Err(e),
-            Err(AllocOrInitError::Alloc(_)) => oom(),
-        }
-    }
-
-    /// Tries to pre-allocates space for a [`Result`] in this `Bump`,
-    /// initializes it using the closure, then returns an exclusive reference
-    /// to its `T` if all [`Ok`].
-    ///
-    /// Iff the allocation fails, the closure is not run.
-    ///
-    /// Iff the closure returns [`Err`], an allocator rewind is *attempted* and
-    /// the `E` instance is moved out of the allocator to be consumed or dropped
-    /// as normal.
-    ///
-    /// See [The `_with` Method Suffix](#initializer-functions-the-_with-method-suffix) for a
-    /// discussion on the differences between the `_with` suffixed methods and
-    /// those methods without it, their performance characteristics, and when
-    /// you might or might not choose a `_with` suffixed method.
-    ///
-    /// For caveats specific to fallible initialization, see
-    /// [The `_try_with` Method Suffix](#fallible-initialization-the-_try_with-method-suffix).
-    ///
-    /// [`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html
-    /// [`Ok`]: https://doc.rust-lang.org/std/result/enum.Result.html#variant.Ok
-    /// [`Err`]: https://doc.rust-lang.org/std/result/enum.Result.html#variant.Err
-    ///
-    /// ## Errors
-    ///
-    /// Errors with the [`Alloc`](`AllocOrInitError::Alloc`) variant iff
-    /// reserving space for `Result<T, E>` fails.
-    ///
-    /// Iff the allocation succeeds but `f` fails, that error is forwarded by
-    /// value inside the [`Init`](`AllocOrInitError::Init`) variant.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// let bump = bumpalo::Bump::new();
-    /// let x = bump.try_alloc_try_with(|| Ok("hello"))?;
-    /// assert_eq!(*x, "hello");
-    /// # Result::<_, bumpalo::AllocOrInitError<()>>::Ok(())
-    /// ```
-    #[inline(always)]
-    pub fn try_alloc_try_with<F, T, E>(&self, f: F) -> Result<&mut T, AllocOrInitError<E>>
-    where
-        F: FnOnce() -> Result<T, E>,
-    {
-        let rewind_footer = self.current_chunk_footer.get();
-        let rewind_footer_ptr = unsafe { rewind_footer.as_ref() }.ptr.get();
-        let ptr = self.try_alloc_with(f)?;
-        let ptr = NonNull::from(ptr).cast::<u8>();
-        let guard = unsafe { RewindGuard::new(self, ptr, rewind_footer, rewind_footer_ptr) };
-        match unsafe { guard.ptr.cast::<Result<T, E>>().as_mut() } {
-            Ok(t) => {
-                guard.finish();
-                Ok(unsafe { NonNull::from(t).as_mut() })
-            }
-            Err(e) => unsafe {
-                // Read the error out and then let the guard rewind.
-                Err(AllocOrInitError::Init(NonNull::from(e).as_ptr().read()))
-            },
-        }
-    }
-
-    /// `Copy` a slice into this `Bump` and return an exclusive reference to
-    /// the copy.
-    ///
-    /// ## Panics
-    ///
-    /// Panics if reserving space for the slice fails.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// let bump = bumpalo::Bump::new();
-    /// let x = bump.alloc_slice_copy(&[1, 2, 3]);
-    /// assert_eq!(x, &[1, 2, 3]);
-    /// ```
-    #[inline(always)]
-    pub fn alloc_slice_copy<T>(&self, src: &[T]) -> &mut [T]
-    where
-        T: Copy,
-    {
-        let layout = Layout::for_value(src);
-        let dst = self.alloc_layout(layout).cast::<T>();
-
-        unsafe {
-            ptr::copy_nonoverlapping(src.as_ptr(), dst.as_ptr(), src.len());
-            slice::from_raw_parts_mut(dst.as_ptr(), src.len())
-        }
-    }
-
-    /// Like `alloc_slice_copy`, but does not panic in case of allocation failure.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// let bump = bumpalo::Bump::new();
-    /// let x = bump.try_alloc_slice_copy(&[1, 2, 3]);
-    /// assert_eq!(x, Ok(&mut[1, 2, 3] as &mut [_]));
-    ///
-    ///
-    /// let bump = bumpalo::Bump::new();
-    /// bump.set_allocation_limit(Some(4));
-    /// let x = bump.try_alloc_slice_copy(&[1, 2, 3, 4, 5, 6]);
-    /// assert_eq!(x, Err(bumpalo::AllocErr)); // too big
-    /// ```
-    #[inline(always)]
-    pub fn try_alloc_slice_copy<T>(&self, src: &[T]) -> Result<&mut [T], AllocErr>
-    where
-        T: Copy,
-    {
-        let layout = Layout::for_value(src);
-        let dst = self.try_alloc_layout(layout)?.cast::<T>();
-        let result = unsafe {
-            core::ptr::copy_nonoverlapping(src.as_ptr(), dst.as_ptr(), src.len());
-            slice::from_raw_parts_mut(dst.as_ptr(), src.len())
-        };
-        Ok(result)
-    }
-
-    /// `Clone` a slice into this `Bump` and return an exclusive reference to
-    /// the clone. Prefer [`alloc_slice_copy`](#method.alloc_slice_copy) if `T` is `Copy`.
-    ///
-    /// ## Panics
-    ///
-    /// Panics if reserving space for the slice fails.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// #[derive(Clone, Debug, Eq, PartialEq)]
-    /// struct Sheep {
-    ///     name: String,
-    /// }
-    ///
-    /// let originals = [
-    ///     Sheep { name: "Alice".into() },
-    ///     Sheep { name: "Bob".into() },
-    ///     Sheep { name: "Cathy".into() },
-    /// ];
-    ///
-    /// let bump = bumpalo::Bump::new();
-    /// let clones = bump.alloc_slice_clone(&originals);
-    /// assert_eq!(originals, clones);
-    /// ```
-    #[inline(always)]
-    pub fn alloc_slice_clone<T>(&self, src: &[T]) -> &mut [T]
-    where
-        T: Clone,
-    {
-        let layout = Layout::for_value(src);
-        let dst = self.alloc_layout(layout).cast::<T>();
-
-        unsafe {
-            for (i, val) in src.iter().cloned().enumerate() {
-                ptr::write(dst.as_ptr().add(i), val);
-            }
-
-            slice::from_raw_parts_mut(dst.as_ptr(), src.len())
-        }
-    }
-
-    /// Like `alloc_slice_clone` but does not panic on failure.
-    #[inline(always)]
-    pub fn try_alloc_slice_clone<T>(&self, src: &[T]) -> Result<&mut [T], AllocErr>
-    where
-        T: Clone,
-    {
-        let layout = Layout::for_value(src);
-        let dst = self.try_alloc_layout(layout)?.cast::<T>();
-
-        unsafe {
-            for (i, val) in src.iter().cloned().enumerate() {
-                ptr::write(dst.as_ptr().add(i), val);
-            }
-
-            Ok(slice::from_raw_parts_mut(dst.as_ptr(), src.len()))
-        }
-    }
-
-    /// `Copy` a string slice into this `Bump` and return an exclusive reference to it.
-    ///
-    /// ## Panics
-    ///
-    /// Panics if reserving space for the string fails.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// let bump = bumpalo::Bump::new();
-    /// let hello = bump.alloc_str("hello world");
-    /// assert_eq!("hello world", hello);
-    /// ```
-    #[inline(always)]
-    pub fn alloc_str(&self, src: &str) -> &mut str {
-        let buffer = self.alloc_slice_copy(src.as_bytes());
-        unsafe {
-            // This is OK, because it already came in as str, so it is guaranteed to be utf8
-            str::from_utf8_unchecked_mut(buffer)
-        }
-    }
-
-    /// Same as `alloc_str` but does not panic on failure.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// let bump = bumpalo::Bump::new();
-    /// let hello = bump.try_alloc_str("hello world").unwrap();
-    /// assert_eq!("hello world", hello);
-    ///
-    ///
-    /// let bump = bumpalo::Bump::new();
-    /// bump.set_allocation_limit(Some(5));
-    /// let hello = bump.try_alloc_str("hello world");
-    /// assert_eq!(Err(bumpalo::AllocErr), hello);
-    /// ```
-    #[inline(always)]
-    pub fn try_alloc_str(&self, src: &str) -> Result<&mut str, AllocErr> {
-        let buffer = self.try_alloc_slice_copy(src.as_bytes())?;
-        unsafe {
-            // This is OK, because it already came in as str, so it is guaranteed to be utf8
-            Ok(str::from_utf8_unchecked_mut(buffer))
-        }
-    }
-
-    /// Allocates a new slice of size `len` into this `Bump` and returns an
-    /// exclusive reference to the copy.
-    ///
-    /// The elements of the slice are initialized using the supplied closure.
-    /// The closure argument is the position in the slice.
-    ///
-    /// ## Panics
-    ///
-    /// Panics if reserving space for the slice fails.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// let bump = bumpalo::Bump::new();
-    /// let x = bump.alloc_slice_fill_with(5, |i| 5 * (i + 1));
-    /// assert_eq!(x, &[5, 10, 15, 20, 25]);
-    /// ```
-    #[inline(always)]
-    pub fn alloc_slice_fill_with<T, F>(&self, len: usize, mut f: F) -> &mut [T]
-    where
-        F: FnMut(usize) -> T,
-    {
-        let layout = Layout::array::<T>(len).unwrap_or_else(|_| oom());
-        let guard = self.alloc_layout_with_rewind(layout);
-
-        unsafe {
-            let mut dst = guard.ptr.cast::<T>();
-            for i in 0..len {
-                ptr::write(dst.as_ptr(), f(i));
-                dst = NonNull::new_unchecked(dst.as_ptr().add(1));
-            }
-
-            let ptr = guard.finish();
-            let result = slice::from_raw_parts_mut(ptr.cast::<T>().as_ptr(), len);
-            debug_assert_eq!(Layout::for_value(result), layout);
-            result
-        }
-    }
-
-    /// Allocates a new slice of size `len` into this `Bump` and returns an
-    /// exclusive reference to the copy, failing if the closure return an Err.
-    ///
-    /// The elements of the slice are initialized using the supplied closure.
-    /// The closure argument is the position in the slice.
-    ///
-    /// ## Panics
-    ///
-    /// Panics if reserving space for the slice fails.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// let bump = bumpalo::Bump::new();
-    /// let x: Result<&mut [usize], ()> = bump.alloc_slice_try_fill_with(5, |i| Ok(5 * i));
-    /// assert_eq!(x, Ok(bump.alloc_slice_copy(&[0, 5, 10, 15, 20])));
-    /// ```
-    ///
-    /// ```
-    /// let bump = bumpalo::Bump::new();
-    /// let x: Result<&mut [usize], ()> = bump.alloc_slice_try_fill_with(
-    ///    5,
-    ///    |n| if n == 2 { Err(()) } else { Ok(n) }
-    /// );
-    /// assert_eq!(x, Err(()));
-    /// ```
-    #[inline(always)]
-    pub fn alloc_slice_try_fill_with<T, F, E>(&self, len: usize, mut f: F) -> Result<&mut [T], E>
-    where
-        F: FnMut(usize) -> Result<T, E>,
-    {
-        let layout = Layout::array::<T>(len).unwrap_or_else(|_| oom());
-        let guard = self.alloc_layout_with_rewind(layout);
-
-        unsafe {
-            let mut dst = guard.ptr.cast::<T>();
-            for i in 0..len {
-                match f(i) {
-                    Ok(el) => {
-                        ptr::write(dst.as_ptr(), el);
-                        dst = NonNull::new_unchecked(dst.as_ptr().add(1));
-                    }
-                    Err(e) => return Err(e),
-                }
-            }
-
-            let ptr = guard.finish();
-            let result = slice::from_raw_parts_mut(ptr.cast::<T>().as_ptr(), len);
-            debug_assert_eq!(Layout::for_value(result), layout);
-            Ok(result)
-        }
-    }
-
-    /// Allocates a new slice of size `len` into this `Bump` and returns an
-    /// exclusive reference to the copy.
-    ///
-    /// The elements of the slice are initialized using the supplied closure.
-    /// The closure argument is the position in the slice.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// let bump = bumpalo::Bump::new();
-    /// let x = bump.try_alloc_slice_fill_with(5, |i| 5 * (i + 1));
-    /// assert_eq!(x, Ok(&mut[5usize, 10, 15, 20, 25] as &mut [_]));
-    ///
-    ///
-    /// let bump = bumpalo::Bump::new();
-    /// bump.set_allocation_limit(Some(4));
-    /// let x = bump.try_alloc_slice_fill_with(10, |i| 5 * (i + 1));
-    /// assert_eq!(x, Err(bumpalo::AllocErr));
-    /// ```
-    #[inline(always)]
-    pub fn try_alloc_slice_fill_with<T, F>(
-        &self,
-        len: usize,
-        mut f: F,
-    ) -> Result<&mut [T], AllocErr>
-    where
-        F: FnMut(usize) -> T,
-    {
-        let layout = Layout::array::<T>(len).map_err(|_| AllocErr)?;
         let guard = self.try_alloc_layout_with_rewind(layout)?;
+        Ok(unsafe { Emplace::new(guard) })
+    }
 
-        unsafe {
-            let mut dst = guard.ptr.cast::<T>();
-            for i in 0..len {
-                ptr::write(dst.as_ptr(), f(i));
-                dst = NonNull::new_unchecked(dst.as_ptr().add(1));
-            }
+    /// Allocate space for a `[T]` slice and return an [`EmplaceSlice`]
+    /// builder.
+    ///
+    /// Starts with a small default capacity. Use
+    /// [`emplace_slice_with_capacity`](Bump::emplace_slice_with_capacity) to
+    /// pre-size the allocation when the final length is known.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the initial allocation fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let mut place = bump.emplace_slice::<u8>();
+    /// place.push(1);
+    /// place.push(2);
+    /// let s = place.into_mut_slice();
+    /// assert_eq!(s, &[1, 2]);
+    /// ```
+    #[inline(always)]
+    pub fn emplace_slice<T>(&self) -> EmplaceSlice<'_, T, MIN_ALIGN> {
+        self.try_emplace_slice().unwrap_or_else(|_| oom())
+    }
 
-            let ptr = guard.finish();
-            let result = slice::from_raw_parts_mut(ptr.cast::<T>().as_ptr(), len);
-            debug_assert_eq!(Layout::for_value(result), layout);
-            Ok(result)
+    /// Try to allocate space for a `[T]` slice and return an
+    /// [`EmplaceSlice`] builder.
+    ///
+    /// ## Errors
+    ///
+    /// Returns an error if the initial allocation fails.
+    #[inline(always)]
+    pub fn try_emplace_slice<T>(&self) -> Result<EmplaceSlice<'_, T, MIN_ALIGN>, AllocErr> {
+        self.try_emplace_slice_with_capacity(1)
+    }
+
+    /// Allocate space for a `[T]` slice with the given `capacity` and return
+    /// an [`EmplaceSlice`] builder.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the allocation fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let data = [1u8, 2, 3];
+    /// let s = bump.emplace_slice_with_capacity(data.len()).copy_slice(&data);
+    /// assert_eq!(s, &[1, 2, 3]);
+    /// ```
+    #[inline(always)]
+    pub fn emplace_slice_with_capacity<T>(
+        &self,
+        capacity: usize,
+    ) -> EmplaceSlice<'_, T, MIN_ALIGN> {
+        self.try_emplace_slice_with_capacity(capacity)
+            .unwrap_or_else(|_| oom())
+    }
+
+    /// Try to allocate space for a `[T]` slice with the given `capacity` and
+    /// return an [`EmplaceSlice`] builder.
+    ///
+    /// ## Errors
+    ///
+    /// Returns an error if the allocation fails.
+    #[inline(always)]
+    pub fn try_emplace_slice_with_capacity<T>(
+        &self,
+        capacity: usize,
+    ) -> Result<EmplaceSlice<'_, T, MIN_ALIGN>, AllocErr> {
+        if mem::size_of::<T>() == 0 {
+            let layout = Layout::new::<T>();
+            let guard = self.try_alloc_layout_with_rewind(layout)?;
+            return Ok(unsafe { EmplaceSlice::new(guard, usize::MAX) });
         }
+        let layout = Layout::array::<T>(capacity).map_err(|_| AllocErr)?;
+        let guard = self.try_alloc_layout_with_rewind(layout)?;
+        Ok(unsafe { EmplaceSlice::new(guard, capacity) })
     }
 
-    /// Allocates a new slice of size `len` into this `Bump` and returns an
-    /// exclusive reference to the copy.
-    ///
-    /// All elements of the slice are initialized to `value`.
+    /// Allocate space for a string and return an [`EmplaceStr`] builder.
     ///
     /// ## Panics
     ///
-    /// Panics if reserving space for the slice fails.
+    /// Panics if the initial allocation fails.
     ///
     /// ## Example
     ///
     /// ```
     /// let bump = bumpalo::Bump::new();
-    /// let x = bump.alloc_slice_fill_copy(5, 42);
-    /// assert_eq!(x, &[42, 42, 42, 42, 42]);
+    /// let mut place = bump.emplace_str();
+    /// place.push_str("hello");
+    /// let s = place.into_str();
+    /// assert_eq!(s, "hello");
     /// ```
     #[inline(always)]
-    pub fn alloc_slice_fill_copy<T: Copy>(&self, len: usize, value: T) -> &mut [T] {
-        self.alloc_slice_fill_with(len, |_| value)
+    pub fn emplace_str(&self) -> EmplaceStr<'_, MIN_ALIGN> {
+        self.try_emplace_str().unwrap_or_else(|_| oom())
     }
 
-    /// Same as `alloc_slice_fill_copy` but does not panic on failure.
+    /// Try to allocate space for a string and return an [`EmplaceStr`]
+    /// builder.
+    ///
+    /// ## Errors
+    ///
+    /// Returns an error if the initial allocation fails.
     #[inline(always)]
-    pub fn try_alloc_slice_fill_copy<T: Copy>(
+    pub fn try_emplace_str(&self) -> Result<EmplaceStr<'_, MIN_ALIGN>, AllocErr> {
+        let slice = self.try_emplace_slice::<u8>()?;
+        Ok(unsafe { EmplaceStr::new(slice) })
+    }
+
+    /// Allocate space for a string with the given byte `capacity` and return
+    /// an [`EmplaceStr`] builder.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the allocation fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let s = bump.emplace_str_with_capacity(5).write_str("hello");
+    /// assert_eq!(s, "hello");
+    /// ```
+    #[inline(always)]
+    pub fn emplace_str_with_capacity(&self, capacity: usize) -> EmplaceStr<'_, MIN_ALIGN> {
+        self.try_emplace_str_with_capacity(capacity)
+            .unwrap_or_else(|_| oom())
+    }
+
+    /// Try to allocate space for a string with the given byte `capacity` and
+    /// return an [`EmplaceStr`] builder.
+    ///
+    /// ## Errors
+    ///
+    /// Returns an error if the allocation fails.
+    #[inline(always)]
+    pub fn try_emplace_str_with_capacity(
         &self,
-        len: usize,
-        value: T,
-    ) -> Result<&mut [T], AllocErr> {
-        self.try_alloc_slice_fill_with(len, |_| value)
-    }
-
-    /// Allocates a new slice of size `len` slice into this `Bump` and return an
-    /// exclusive reference to the copy.
-    ///
-    /// All elements of the slice are initialized to `value.clone()`.
-    ///
-    /// ## Panics
-    ///
-    /// Panics if reserving space for the slice fails.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// let bump = bumpalo::Bump::new();
-    /// let s: String = "Hello Bump!".to_string();
-    /// let x: &[String] = bump.alloc_slice_fill_clone(2, &s);
-    /// assert_eq!(x.len(), 2);
-    /// assert_eq!(&x[0], &s);
-    /// assert_eq!(&x[1], &s);
-    /// ```
-    #[inline(always)]
-    pub fn alloc_slice_fill_clone<T: Clone>(&self, len: usize, value: &T) -> &mut [T] {
-        self.alloc_slice_fill_with(len, |_| value.clone())
-    }
-
-    /// Like `alloc_slice_fill_clone` but does not panic on failure.
-    #[inline(always)]
-    pub fn try_alloc_slice_fill_clone<T: Clone>(
-        &self,
-        len: usize,
-        value: &T,
-    ) -> Result<&mut [T], AllocErr> {
-        self.try_alloc_slice_fill_with(len, |_| value.clone())
-    }
-
-    /// Allocates a new slice of size `len` slice into this `Bump` and return an
-    /// exclusive reference to the copy.
-    ///
-    /// The elements are initialized using the supplied iterator.
-    ///
-    /// ## Panics
-    ///
-    /// Panics if reserving space for the slice fails, or if the supplied
-    /// iterator returns fewer elements than it promised.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// let bump = bumpalo::Bump::new();
-    /// let x: &[i32] = bump.alloc_slice_fill_iter([2, 3, 5].iter().cloned().map(|i| i * i));
-    /// assert_eq!(x, [4, 9, 25]);
-    /// ```
-    #[inline(always)]
-    pub fn alloc_slice_fill_iter<T, I>(&self, iter: I) -> &mut [T]
-    where
-        I: IntoIterator<Item = T>,
-        I::IntoIter: ExactSizeIterator,
-    {
-        let mut iter = iter.into_iter();
-        self.alloc_slice_fill_with(iter.len(), |_| {
-            iter.next().expect("Iterator supplied too few elements")
-        })
-    }
-
-    /// Allocates a new slice of size `len` slice into this `Bump` and return an
-    /// exclusive reference to the copy, failing if the iterator returns an Err.
-    ///
-    /// The elements are initialized using the supplied iterator.
-    ///
-    /// ## Panics
-    ///
-    /// Panics if reserving space for the slice fails, or if the supplied
-    /// iterator returns fewer elements than it promised.
-    ///
-    /// ## Examples
-    ///
-    /// ```
-    /// let bump = bumpalo::Bump::new();
-    /// let x: Result<&mut [i32], ()> = bump.alloc_slice_try_fill_iter(
-    ///    [2, 3, 5].iter().cloned().map(|i| Ok(i * i))
-    /// );
-    /// assert_eq!(x, Ok(bump.alloc_slice_copy(&[4, 9, 25])));
-    /// ```
-    ///
-    /// ```
-    /// let bump = bumpalo::Bump::new();
-    /// let x: Result<&mut [i32], ()> = bump.alloc_slice_try_fill_iter(
-    ///    [Ok(2), Err(()), Ok(5)].iter().cloned()
-    /// );
-    /// assert_eq!(x, Err(()));
-    /// ```
-    #[inline(always)]
-    pub fn alloc_slice_try_fill_iter<T, I, E>(&self, iter: I) -> Result<&mut [T], E>
-    where
-        I: IntoIterator<Item = Result<T, E>>,
-        I::IntoIter: ExactSizeIterator,
-    {
-        let mut iter = iter.into_iter();
-        self.alloc_slice_try_fill_with(iter.len(), |_| {
-            iter.next().expect("Iterator supplied too few elements")
-        })
-    }
-
-    /// Allocates a new slice of size `iter.len()` slice into this `Bump` and return an
-    /// exclusive reference to the copy. Does not panic on failure.
-    ///
-    /// The elements are initialized using the supplied iterator.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// let bump = bumpalo::Bump::new();
-    /// let x: &[i32] = bump.try_alloc_slice_fill_iter([2, 3, 5]
-    ///     .iter().cloned().map(|i| i * i)).unwrap();
-    /// assert_eq!(x, [4, 9, 25]);
-    /// ```
-    #[inline(always)]
-    pub fn try_alloc_slice_fill_iter<T, I>(&self, iter: I) -> Result<&mut [T], AllocErr>
-    where
-        I: IntoIterator<Item = T>,
-        I::IntoIter: ExactSizeIterator,
-    {
-        let mut iter = iter.into_iter();
-        self.try_alloc_slice_fill_with(iter.len(), |_| {
-            iter.next().expect("Iterator supplied too few elements")
-        })
-    }
-
-    /// Allocates a new slice of size `len` slice into this `Bump` and return an
-    /// exclusive reference to the copy.
-    ///
-    /// All elements of the slice are initialized to [`T::default()`].
-    ///
-    /// [`T::default()`]: https://doc.rust-lang.org/std/default/trait.Default.html#tymethod.default
-    ///
-    /// ## Panics
-    ///
-    /// Panics if reserving space for the slice fails.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// let bump = bumpalo::Bump::new();
-    /// let x = bump.alloc_slice_fill_default::<u32>(5);
-    /// assert_eq!(x, &[0, 0, 0, 0, 0]);
-    /// ```
-    #[inline(always)]
-    pub fn alloc_slice_fill_default<T: Default>(&self, len: usize) -> &mut [T] {
-        self.alloc_slice_fill_with(len, |_| T::default())
-    }
-
-    /// Like `alloc_slice_fill_default` but does not panic on failure.
-    #[inline(always)]
-    pub fn try_alloc_slice_fill_default<T: Default>(
-        &self,
-        len: usize,
-    ) -> Result<&mut [T], AllocErr> {
-        self.try_alloc_slice_fill_with(len, |_| T::default())
+        capacity: usize,
+    ) -> Result<EmplaceStr<'_, MIN_ALIGN>, AllocErr> {
+        let slice = self.try_emplace_slice_with_capacity::<u8>(capacity)?;
+        Ok(unsafe { EmplaceStr::new(slice) })
     }
 
     /// Allocate space for an object with the given `Layout`.
@@ -2074,12 +1513,6 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         let rewind_footer_ptr = unsafe { rewind_footer.as_ref().ptr.get() };
         let ptr = self.try_alloc_layout(layout)?;
         Ok(unsafe { RewindGuard::new(self, ptr, rewind_footer, rewind_footer_ptr) })
-    }
-
-    #[inline]
-    fn alloc_layout_with_rewind(&self, layout: Layout) -> RewindGuard<'_, MIN_ALIGN> {
-        self.try_alloc_layout_with_rewind(layout)
-            .unwrap_or_else(|_| oom())
     }
 
     /// Returns an iterator over each chunk of allocated memory that
@@ -2445,6 +1878,8 @@ pub struct ChunkRawIter<'a, const MIN_ALIGN: usize = 1> {
 
 impl<const MIN_ALIGN: usize> Iterator for ChunkRawIter<'_, MIN_ALIGN> {
     type Item = (*mut u8, usize);
+
+    #[inline]
     fn next(&mut self) -> Option<(*mut u8, usize)> {
         unsafe {
             let foot = self.footer.as_ref();
@@ -2578,6 +2013,608 @@ unsafe impl<'a, const MIN_ALIGN: usize> Allocator for &'a Bump<MIN_ALIGN> {
         }
 
         Ok(new_ptr)
+    }
+}
+
+// Allocation convenience methods implemented in terms of the emplacement API.
+impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
+    /// Allocate an object in this `Bump` and return an exclusive reference to
+    /// it.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if reserving space for `T` fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let x = bump.alloc("hello");
+    /// assert_eq!(*x, "hello");
+    /// ```
+    #[inline(always)]
+    pub fn alloc<T>(&self, val: T) -> &mut T {
+        self.emplace().write(val)
+    }
+
+    /// Try to allocate an object in this `Bump` and return an exclusive
+    /// reference to it.
+    ///
+    /// ## Errors
+    ///
+    /// Errors if reserving space for `T` fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let x = bump.try_alloc("hello");
+    /// assert_eq!(x, Ok(&mut "hello"));
+    /// ```
+    #[inline(always)]
+    pub fn try_alloc<T>(&self, val: T) -> Result<&mut T, AllocErr> {
+        Ok(self.try_emplace()?.write(val))
+    }
+
+    /// Pre-allocate space for an object in this `Bump`, initializes it using
+    /// the closure, then returns an exclusive reference to it.
+    ///
+    /// This is equivalent to `bump.emplace().write(f())`. See [Allocation
+    /// Helper Methods](#allocation-helper-methods) for more details.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if reserving space for `T` fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let x = bump.alloc_with(|| "hello");
+    /// assert_eq!(*x, "hello");
+    /// ```
+    #[inline(always)]
+    pub fn alloc_with<F, T>(&self, f: F) -> &mut T
+    where
+        F: FnOnce() -> T,
+    {
+        self.emplace().write(f())
+    }
+
+    /// Tries to pre-allocate space for an object in this `Bump`, initializes
+    /// it using the closure, then returns an exclusive reference to it.
+    ///
+    /// This is equivalent to `bump.try_emplace()?.write(f())`. See [Allocation
+    /// Helper Methods](#allocation-helper-methods) for more details.
+    ///
+    /// ## Errors
+    ///
+    /// Errors if reserving space for `T` fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let x = bump.try_alloc_with(|| "hello");
+    /// assert_eq!(x, Ok(&mut "hello"));
+    /// ```
+    #[inline(always)]
+    pub fn try_alloc_with<F, T>(&self, f: F) -> Result<&mut T, AllocErr>
+    where
+        F: FnOnce() -> T,
+    {
+        Ok(self.try_emplace()?.write(f()))
+    }
+
+    /// Pre-allocates space for a [`Result`] in this `Bump`, initializes it using
+    /// the closure, then returns an exclusive reference to its `T` if [`Ok`].
+    ///
+    /// This is roughly equivalent to `bump.emplace().write(f()?)`. See
+    /// [Allocation Helper Methods](#allocation-helper-methods) for more
+    /// details.
+    ///
+    /// [`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html
+    /// [`Ok`]: https://doc.rust-lang.org/std/result/enum.Result.html#variant.Ok
+    ///
+    /// ## Errors
+    ///
+    /// If the allocation succeeds but `f` fails, that error is forwarded by value.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if reserving space for `Result<T, E>` fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let x = bump.alloc_try_with(|| Ok("hello"))?;
+    /// assert_eq!(*x, "hello");
+    /// # Result::<_, ()>::Ok(())
+    /// ```
+    #[inline(always)]
+    pub fn alloc_try_with<F, T, E>(&self, f: F) -> Result<&mut T, E>
+    where
+        F: FnOnce() -> Result<T, E>,
+    {
+        match self.try_alloc_try_with(f) {
+            Ok(x) => Ok(x),
+            Err(AllocOrInitError::Init(e)) => Err(e),
+            Err(AllocOrInitError::Alloc(_)) => oom(),
+        }
+    }
+
+    /// Tries to pre-allocates space for a [`Result`] in this `Bump`,
+    /// initializes it using the closure, then returns an exclusive reference
+    /// to its `T` if all [`Ok`].
+    ///
+    /// This is roughly equivalent to `bump.try_emplace()?.write(f()?)`. See
+    /// [Allocation Helper Methods](#allocation-helper-methods) for more
+    /// details.
+    ///
+    /// [`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html
+    /// [`Ok`]: https://doc.rust-lang.org/std/result/enum.Result.html#variant.Ok
+    ///
+    /// ## Errors
+    ///
+    /// Errors with the [`AllocOrInitError::Alloc`](`AllocOrInitError::Alloc`)
+    /// error variant when reserving space for `Result<T, E>` fails.
+    ///
+    /// If the allocation succeeds but `f` fails, that error is forwarded by
+    /// value inside the [`AllocOrInitError::Init`](`AllocOrInitError::Init`)
+    /// error variant.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let x = bump.try_alloc_try_with(|| Ok("hello"))?;
+    /// assert_eq!(*x, "hello");
+    /// # Result::<_, bumpalo::AllocOrInitError<()>>::Ok(())
+    /// ```
+    #[inline(always)]
+    pub fn try_alloc_try_with<F, T, E>(&self, f: F) -> Result<&mut T, AllocOrInitError<E>>
+    where
+        F: FnOnce() -> Result<T, E>,
+    {
+        let rewind_footer = self.current_chunk_footer.get();
+        let rewind_footer_ptr = unsafe { rewind_footer.as_ref() }.ptr.get();
+        let ptr = self.try_alloc_with(f)?;
+        let ptr = NonNull::from(ptr).cast::<u8>();
+        let guard = unsafe { RewindGuard::new(self, ptr, rewind_footer, rewind_footer_ptr) };
+        match unsafe { guard.ptr.cast::<Result<T, E>>().as_mut() } {
+            Ok(t) => {
+                guard.finish();
+                Ok(unsafe { NonNull::from(t).as_mut() })
+            }
+            Err(e) => unsafe {
+                // Read the error out and then let the guard rewind.
+                Err(AllocOrInitError::Init(NonNull::from(e).as_ptr().read()))
+            },
+        }
+    }
+
+    /// `Copy` a slice into this `Bump` and return an exclusive reference to
+    /// the copy.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if reserving space for the slice fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let x = bump.alloc_slice_copy(&[1, 2, 3]);
+    /// assert_eq!(x, &[1, 2, 3]);
+    /// ```
+    #[inline(always)]
+    pub fn alloc_slice_copy<T>(&self, src: &[T]) -> &mut [T]
+    where
+        T: Copy,
+    {
+        self.emplace_slice_with_capacity(src.len()).copy_slice(src)
+    }
+
+    /// Like `alloc_slice_copy`, but does not panic in case of allocation failure.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let x = bump.try_alloc_slice_copy(&[1, 2, 3]);
+    /// assert_eq!(x, Ok(&mut[1, 2, 3] as &mut [_]));
+    ///
+    ///
+    /// let bump = bumpalo::Bump::new();
+    /// bump.set_allocation_limit(Some(4));
+    /// let x = bump.try_alloc_slice_copy(&[1, 2, 3, 4, 5, 6]);
+    /// assert_eq!(x, Err(bumpalo::AllocErr)); // too big
+    /// ```
+    #[inline(always)]
+    pub fn try_alloc_slice_copy<T>(&self, src: &[T]) -> Result<&mut [T], AllocErr>
+    where
+        T: Copy,
+    {
+        self.try_emplace_slice_with_capacity(src.len())?
+            .try_copy_slice(src)
+    }
+
+    /// `Clone` a slice into this `Bump` and return an exclusive reference to
+    /// the clone. Prefer [`alloc_slice_copy`](#method.alloc_slice_copy) if `T` is `Copy`.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if reserving space for the slice fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// #[derive(Clone, Debug, Eq, PartialEq)]
+    /// struct Sheep {
+    ///     name: String,
+    /// }
+    ///
+    /// let originals = [
+    ///     Sheep { name: "Alice".into() },
+    ///     Sheep { name: "Bob".into() },
+    ///     Sheep { name: "Cathy".into() },
+    /// ];
+    ///
+    /// let bump = bumpalo::Bump::new();
+    /// let clones = bump.alloc_slice_clone(&originals);
+    /// assert_eq!(originals, clones);
+    /// ```
+    #[inline(always)]
+    pub fn alloc_slice_clone<T>(&self, src: &[T]) -> &mut [T]
+    where
+        T: Clone,
+    {
+        self.emplace_slice_with_capacity(src.len()).clone_slice(src)
+    }
+
+    /// Like `alloc_slice_clone` but does not panic on failure.
+    #[inline(always)]
+    pub fn try_alloc_slice_clone<T>(&self, src: &[T]) -> Result<&mut [T], AllocErr>
+    where
+        T: Clone,
+    {
+        self.try_emplace_slice_with_capacity(src.len())?
+            .try_clone_slice(src)
+    }
+
+    /// `Copy` a string slice into this `Bump` and return an exclusive reference to it.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if reserving space for the string fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let hello = bump.alloc_str("hello world");
+    /// assert_eq!("hello world", hello);
+    /// ```
+    #[inline(always)]
+    pub fn alloc_str(&self, src: &str) -> &mut str {
+        self.emplace_str_with_capacity(src.len()).write_str(src)
+    }
+
+    /// Same as `alloc_str` but does not panic on failure.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let hello = bump.try_alloc_str("hello world").unwrap();
+    /// assert_eq!("hello world", hello);
+    ///
+    ///
+    /// let bump = bumpalo::Bump::new();
+    /// bump.set_allocation_limit(Some(5));
+    /// let hello = bump.try_alloc_str("hello world");
+    /// assert_eq!(Err(bumpalo::AllocErr), hello);
+    /// ```
+    #[inline(always)]
+    pub fn try_alloc_str(&self, src: &str) -> Result<&mut str, AllocErr> {
+        self.try_emplace_str_with_capacity(src.len())?
+            .try_write_str(src)
+    }
+
+    /// Allocates a new slice of size `len` into this `Bump` and returns an
+    /// exclusive reference to the copy.
+    ///
+    /// The elements of the slice are initialized using the supplied closure.
+    /// The closure argument is the position in the slice.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if reserving space for the slice fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let x = bump.alloc_slice_fill_with(5, |i| 5 * (i + 1));
+    /// assert_eq!(x, &[5, 10, 15, 20, 25]);
+    /// ```
+    #[inline(always)]
+    pub fn alloc_slice_fill_with<T, F>(&self, len: usize, mut f: F) -> &mut [T]
+    where
+        F: FnMut(usize) -> T,
+    {
+        let mut place = self.emplace_slice_with_capacity(len);
+        for i in 0..len {
+            place.push(f(i));
+        }
+        place.into_mut_slice()
+    }
+
+    /// Allocates a new slice of size `len` into this `Bump` and returns an
+    /// exclusive reference to the copy, failing if the closure return an Err.
+    ///
+    /// The elements of the slice are initialized using the supplied closure.
+    /// The closure argument is the position in the slice.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if reserving space for the slice fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let x: Result<&mut [usize], ()> = bump.alloc_slice_try_fill_with(5, |i| Ok(5 * i));
+    /// assert_eq!(x, Ok(bump.alloc_slice_copy(&[0, 5, 10, 15, 20])));
+    /// ```
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let x: Result<&mut [usize], ()> = bump.alloc_slice_try_fill_with(
+    ///    5,
+    ///    |n| if n == 2 { Err(()) } else { Ok(n) }
+    /// );
+    /// assert_eq!(x, Err(()));
+    /// ```
+    #[inline(always)]
+    pub fn alloc_slice_try_fill_with<T, F, E>(&self, len: usize, mut f: F) -> Result<&mut [T], E>
+    where
+        F: FnMut(usize) -> Result<T, E>,
+    {
+        let mut place = self.emplace_slice_with_capacity(len);
+        for i in 0..len {
+            match f(i) {
+                Ok(val) => place.push(val),
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(place.into_mut_slice())
+    }
+
+    /// Allocates a new slice of size `len` into this `Bump` and returns an
+    /// exclusive reference to the copy.
+    ///
+    /// The elements of the slice are initialized using the supplied closure.
+    /// The closure argument is the position in the slice.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let x = bump.try_alloc_slice_fill_with(5, |i| 5 * (i + 1));
+    /// assert_eq!(x, Ok(&mut[5usize, 10, 15, 20, 25] as &mut [_]));
+    ///
+    ///
+    /// let bump = bumpalo::Bump::new();
+    /// bump.set_allocation_limit(Some(4));
+    /// let x = bump.try_alloc_slice_fill_with(10, |i| 5 * (i + 1));
+    /// assert_eq!(x, Err(bumpalo::AllocErr));
+    /// ```
+    #[inline(always)]
+    pub fn try_alloc_slice_fill_with<T, F>(
+        &self,
+        len: usize,
+        mut f: F,
+    ) -> Result<&mut [T], AllocErr>
+    where
+        F: FnMut(usize) -> T,
+    {
+        let mut place = self.try_emplace_slice_with_capacity(len)?;
+        for i in 0..len {
+            place.push(f(i));
+        }
+        Ok(place.into_mut_slice())
+    }
+
+    /// Allocates a new slice of size `len` into this `Bump` and returns an
+    /// exclusive reference to the copy.
+    ///
+    /// All elements of the slice are initialized to `value`.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if reserving space for the slice fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let x = bump.alloc_slice_fill_copy(5, 42);
+    /// assert_eq!(x, &[42, 42, 42, 42, 42]);
+    /// ```
+    #[inline(always)]
+    pub fn alloc_slice_fill_copy<T: Copy>(&self, len: usize, value: T) -> &mut [T] {
+        self.alloc_slice_fill_with(len, |_| value)
+    }
+
+    /// Same as `alloc_slice_fill_copy` but does not panic on failure.
+    #[inline(always)]
+    pub fn try_alloc_slice_fill_copy<T: Copy>(
+        &self,
+        len: usize,
+        value: T,
+    ) -> Result<&mut [T], AllocErr> {
+        self.try_alloc_slice_fill_with(len, |_| value)
+    }
+
+    /// Allocates a new slice of size `len` slice into this `Bump` and return an
+    /// exclusive reference to the copy.
+    ///
+    /// All elements of the slice are initialized to `value.clone()`.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if reserving space for the slice fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let s: String = "Hello Bump!".to_string();
+    /// let x: &[String] = bump.alloc_slice_fill_clone(2, &s);
+    /// assert_eq!(x.len(), 2);
+    /// assert_eq!(&x[0], &s);
+    /// assert_eq!(&x[1], &s);
+    /// ```
+    #[inline(always)]
+    pub fn alloc_slice_fill_clone<T: Clone>(&self, len: usize, value: &T) -> &mut [T] {
+        self.alloc_slice_fill_with(len, |_| value.clone())
+    }
+
+    /// Like `alloc_slice_fill_clone` but does not panic on failure.
+    #[inline(always)]
+    pub fn try_alloc_slice_fill_clone<T: Clone>(
+        &self,
+        len: usize,
+        value: &T,
+    ) -> Result<&mut [T], AllocErr> {
+        self.try_alloc_slice_fill_with(len, |_| value.clone())
+    }
+
+    /// Allocates a new slice of size `len` slice into this `Bump` and return an
+    /// exclusive reference to the copy.
+    ///
+    /// The elements are initialized using the supplied iterator.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if reserving space for the slice fails, or if the supplied
+    /// iterator returns fewer elements than it promised.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let x: &[i32] = bump.alloc_slice_fill_iter([2, 3, 5].iter().cloned().map(|i| i * i));
+    /// assert_eq!(x, [4, 9, 25]);
+    /// ```
+    #[inline(always)]
+    pub fn alloc_slice_fill_iter<T, I>(&self, iter: I) -> &mut [T]
+    where
+        I: IntoIterator<Item = T>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        let mut iter = iter.into_iter();
+        self.alloc_slice_fill_with(iter.len(), |_| {
+            iter.next().expect("Iterator supplied too few elements")
+        })
+    }
+
+    /// Allocates a new slice of size `len` slice into this `Bump` and return an
+    /// exclusive reference to the copy, failing if the iterator returns an Err.
+    ///
+    /// The elements are initialized using the supplied iterator.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if reserving space for the slice fails, or if the supplied
+    /// iterator returns fewer elements than it promised.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let x: Result<&mut [i32], ()> = bump.alloc_slice_try_fill_iter(
+    ///    [2, 3, 5].iter().cloned().map(|i| Ok(i * i))
+    /// );
+    /// assert_eq!(x, Ok(bump.alloc_slice_copy(&[4, 9, 25])));
+    /// ```
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let x: Result<&mut [i32], ()> = bump.alloc_slice_try_fill_iter(
+    ///    [Ok(2), Err(()), Ok(5)].iter().cloned()
+    /// );
+    /// assert_eq!(x, Err(()));
+    /// ```
+    #[inline(always)]
+    pub fn alloc_slice_try_fill_iter<T, I, E>(&self, iter: I) -> Result<&mut [T], E>
+    where
+        I: IntoIterator<Item = Result<T, E>>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        let mut iter = iter.into_iter();
+        self.alloc_slice_try_fill_with(iter.len(), |_| {
+            iter.next().expect("Iterator supplied too few elements")
+        })
+    }
+
+    /// Allocates a new slice of size `iter.len()` slice into this `Bump` and return an
+    /// exclusive reference to the copy. Does not panic on failure.
+    ///
+    /// The elements are initialized using the supplied iterator.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let x: &[i32] = bump.try_alloc_slice_fill_iter([2, 3, 5]
+    ///     .iter().cloned().map(|i| i * i)).unwrap();
+    /// assert_eq!(x, [4, 9, 25]);
+    /// ```
+    #[inline(always)]
+    pub fn try_alloc_slice_fill_iter<T, I>(&self, iter: I) -> Result<&mut [T], AllocErr>
+    where
+        I: IntoIterator<Item = T>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        let mut iter = iter.into_iter();
+        self.try_alloc_slice_fill_with(iter.len(), |_| {
+            iter.next().expect("Iterator supplied too few elements")
+        })
+    }
+
+    /// Allocates a new slice of size `len` slice into this `Bump` and return an
+    /// exclusive reference to the copy.
+    ///
+    /// All elements of the slice are initialized to [`T::default()`].
+    ///
+    /// [`T::default()`]: https://doc.rust-lang.org/std/default/trait.Default.html#tymethod.default
+    ///
+    /// ## Panics
+    ///
+    /// Panics if reserving space for the slice fails.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let bump = bumpalo::Bump::new();
+    /// let x = bump.alloc_slice_fill_default::<u32>(5);
+    /// assert_eq!(x, &[0, 0, 0, 0, 0]);
+    /// ```
+    #[inline(always)]
+    pub fn alloc_slice_fill_default<T: Default>(&self, len: usize) -> &mut [T] {
+        self.alloc_slice_fill_with(len, |_| T::default())
+    }
+
+    /// Like `alloc_slice_fill_default` but does not panic on failure.
+    #[inline(always)]
+    pub fn try_alloc_slice_fill_default<T: Default>(
+        &self,
+        len: usize,
+    ) -> Result<&mut [T], AllocErr> {
+        self.try_alloc_slice_fill_with(len, |_| T::default())
     }
 }
 

--- a/tests/all/emplace.rs
+++ b/tests/all/emplace.rs
@@ -1,0 +1,387 @@
+use crate::quickcheck;
+use ::quickcheck::{Arbitrary, Gen};
+use bumpalo::Bump;
+use std::mem;
+
+// =============================================================================
+// EmplaceSlice operation-sequence testing
+// =============================================================================
+
+const MAX_EMPLACE_OPS: usize = 64;
+const MAX_EMPLACE_EXTEND_LEN: usize = 32;
+const MAX_EMPLACE_RESERVE: usize = 64;
+
+#[derive(Clone, Debug)]
+enum EmplaceSliceOp {
+    Push(u8),
+    Extend(Vec<u8>),
+    Reserve(usize),
+    ShrinkToFit,
+}
+
+impl Arbitrary for EmplaceSliceOp {
+    fn arbitrary(g: &mut Gen) -> Self {
+        match u8::arbitrary(g) % 4 {
+            0 => EmplaceSliceOp::Push(u8::arbitrary(g)),
+            1 => {
+                let mut v = Vec::<u8>::arbitrary(g);
+                v.truncate(MAX_EMPLACE_EXTEND_LEN);
+                EmplaceSliceOp::Extend(v)
+            }
+            2 => EmplaceSliceOp::Reserve(usize::from(u8::arbitrary(g)) % MAX_EMPLACE_RESERVE),
+            3 => EmplaceSliceOp::ShrinkToFit,
+            _ => unreachable!(),
+        }
+    }
+
+    fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+        match self {
+            EmplaceSliceOp::Push(v) => Box::new(v.shrink().map(EmplaceSliceOp::Push)),
+            EmplaceSliceOp::Extend(v) => Box::new(v.shrink().map(EmplaceSliceOp::Extend)),
+            EmplaceSliceOp::Reserve(n) => Box::new(n.shrink().map(EmplaceSliceOp::Reserve)),
+            EmplaceSliceOp::ShrinkToFit => Box::new(std::iter::empty()),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct EmplaceSliceProgram(Vec<EmplaceSliceOp>);
+
+impl Arbitrary for EmplaceSliceProgram {
+    fn arbitrary(g: &mut Gen) -> Self {
+        let mut ops = Vec::<EmplaceSliceOp>::arbitrary(g);
+        ops.truncate(MAX_EMPLACE_OPS);
+        EmplaceSliceProgram(ops)
+    }
+
+    fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+        Box::new(self.0.shrink().map(|mut ops| {
+            ops.truncate(MAX_EMPLACE_OPS);
+            EmplaceSliceProgram(ops)
+        }))
+    }
+}
+
+fn range_of<T>(p: *const T, len: usize) -> (usize, usize) {
+    let start = p as usize;
+    let end = start + mem::size_of::<T>() * len;
+    (start, end)
+}
+
+fn ranges_overlap(a: (usize, usize), b: (usize, usize)) -> bool {
+    a.0 < b.1 && b.0 < a.1
+}
+
+// =============================================================================
+// Quickcheck tests
+// =============================================================================
+
+quickcheck! {
+    fn emplace_single_roundtrip(values: Vec<u64>) -> () {
+        let bump = Bump::new();
+        let mut ranges = vec![];
+
+        for v in &values {
+            let r = bump.emplace().write(*v);
+            assert_eq!(*r, *v);
+            let rng = range_of(r as *const u64, 1);
+            assert_eq!(r as *const u64 as usize % mem::align_of::<u64>(), 0);
+            for prev in &ranges {
+                assert!(!ranges_overlap(rng, *prev));
+            }
+            ranges.push(rng);
+        }
+    }
+
+    fn try_emplace_single_roundtrip(values: Vec<u32>) -> () {
+        let bump = Bump::new();
+        for v in &values {
+            let r = bump.try_emplace().unwrap().write(*v);
+            assert_eq!(*r, *v);
+            assert_eq!(r as *const u32 as usize % mem::align_of::<u32>(), 0);
+        }
+    }
+
+    fn emplace_slice_operation_sequences(program: EmplaceSliceProgram) -> () {
+        let bump = Bump::new();
+        let mut place = bump.emplace_slice::<u8>();
+        let mut model: Vec<u8> = Vec::new();
+
+        for op in &program.0 {
+            match op {
+                EmplaceSliceOp::Push(val) => {
+                    place.push(*val);
+                    model.push(*val);
+                }
+                EmplaceSliceOp::Extend(vals) => {
+                    place.extend(vals.iter().copied());
+                    model.extend(vals.iter().copied());
+                }
+                EmplaceSliceOp::Reserve(n) => {
+                    place.reserve(*n);
+                    assert!(place.capacity() >= place.len() + n);
+                }
+                EmplaceSliceOp::ShrinkToFit => {
+                    place.shrink_to_fit();
+                }
+            }
+
+            assert_eq!(place.len(), model.len());
+            assert!(place.capacity() >= place.len());
+            assert_eq!(place.as_slice(), model.as_slice());
+        }
+
+        let result = place.into_mut_slice();
+        assert_eq!(result, model.as_slice());
+    }
+
+    fn emplace_slice_copy(data: Vec<u8>) -> () {
+        let bump = Bump::new();
+        let place = bump.emplace_slice_with_capacity(data.len());
+        let result = place.copy_slice(&data);
+        assert_eq!(result, data.as_slice());
+    }
+
+    fn emplace_slice_clone(data: Vec<u8>) -> () {
+        let bump = Bump::new();
+        let place = bump.emplace_slice_with_capacity(data.len());
+        let result = place.clone_slice(&data);
+        assert_eq!(result, data.as_slice());
+    }
+
+    fn emplace_slice_write_iter(data: Vec<u8>) -> () {
+        let bump = Bump::new();
+        let place = bump.emplace_slice::<u8>();
+        let result = place.write_iter(data.iter().copied());
+        assert_eq!(result, data.as_slice());
+    }
+
+    fn emplace_str_roundtrip(strings: Vec<String>) -> () {
+        let bump = Bump::new();
+        for s in &strings {
+            let r = bump.emplace_str_with_capacity(s.len()).write_str(s);
+            assert_eq!(r, s.as_str());
+        }
+    }
+
+    fn emplace_str_push_chars(s: String) -> () {
+        let bump = Bump::new();
+        let mut place = bump.emplace_str();
+        for c in s.chars() {
+            place.push(c);
+        }
+        let result = place.into_str();
+        assert_eq!(result, s.as_str());
+    }
+
+    fn emplace_str_push_strs(parts: Vec<String>) -> () {
+        let bump = Bump::new();
+        let mut place = bump.emplace_str();
+        let mut model = String::new();
+        for part in &parts {
+            place.push_str(part);
+            model.push_str(part);
+        }
+        let result = place.into_str();
+        assert_eq!(result, model.as_str());
+    }
+
+    fn heterogeneous_emplace_no_overlap(ops: Vec<u8>) -> () {
+        let bump = Bump::new();
+        let mut ranges: Vec<(usize, usize)> = vec![];
+
+        for (i, op) in ops.iter().enumerate() {
+            let rng = match op % 4 {
+                0 => {
+                    let r = bump.emplace().write(i as u64);
+                    range_of(r as *const u64, 1)
+                }
+                1 => {
+                    let r = bump.alloc(i as u32);
+                    range_of(r as *const u32, 1)
+                }
+                2 => {
+                    let data = [i as u8; 4];
+                    let r = bump.emplace_slice_with_capacity(4).copy_slice(&data);
+                    range_of(r.as_ptr(), r.len())
+                }
+                3 => {
+                    let s = bump.emplace_str().write_str("hi");
+                    range_of(s.as_ptr(), s.len())
+                }
+                _ => unreachable!(),
+            };
+            if rng.0 != rng.1 {
+                for prev in &ranges {
+                    assert!(
+                        !ranges_overlap(rng, *prev),
+                        "overlap: {:?} vs {:?}",
+                        rng,
+                        prev
+                    );
+                }
+                ranges.push(rng);
+            }
+        }
+    }
+
+    fn emplace_rewind_on_drop(values: Vec<u64>) -> () {
+        let bump = Bump::new();
+        for v in &values {
+            let capacity_before = bump.chunk_capacity();
+            {
+                let _place = bump.emplace::<u64>();
+                // Drop without writing -- should rewind and reclaim the space.
+            }
+            let capacity_after = bump.chunk_capacity();
+            // If the emplace stayed in the same chunk, capacity should be
+            // fully restored.  If it triggered a new chunk, capacity_after
+            // will be the full new-chunk size which is still >= capacity_before.
+            assert!(
+                capacity_after >= capacity_before,
+                "capacity should be at least restored on drop: before={}, after={}",
+                capacity_before, capacity_after
+            );
+
+            // Verify we can still allocate correctly after the rewind.
+            let r = bump.alloc(*v);
+            assert_eq!(*r, *v);
+        }
+    }
+
+    fn emplace_slice_rewind_on_drop(lens: Vec<u8>) -> () {
+        let bump = Bump::new();
+        for len in &lens {
+            let len = (*len as usize) % 16;
+            if len == 0 {
+                continue;
+            }
+            let capacity_before = bump.chunk_capacity();
+            {
+                let place = bump.emplace_slice_with_capacity::<u8>(len);
+                drop(place);
+            }
+            let capacity_after = bump.chunk_capacity();
+            assert!(
+                capacity_after >= capacity_before,
+                "capacity should be reclaimed on drop: before={}, after={}",
+                capacity_before,
+                capacity_after
+            );
+        }
+    }
+
+    fn zoo_equivalence_alloc(values: Vec<u64>) -> () {
+        let bump1 = Bump::new();
+        let bump2 = Bump::new();
+        for v in &values {
+            let r1 = bump1.alloc(*v);
+            let r2 = bump2.emplace().write(*v);
+            assert_eq!(*r1, *r2);
+        }
+    }
+
+    fn zoo_equivalence_slice_copy(slices: Vec<Vec<u8>>) -> () {
+        let bump1 = Bump::new();
+        let bump2 = Bump::new();
+        for s in &slices {
+            let r1 = bump1.alloc_slice_copy(s);
+            let r2 = bump2.emplace_slice_with_capacity(s.len()).copy_slice(s);
+            assert_eq!(r1, r2);
+        }
+    }
+
+    fn zoo_equivalence_str(strings: Vec<String>) -> () {
+        let bump1 = Bump::new();
+        let bump2 = Bump::new();
+        for s in &strings {
+            let r1 = bump1.alloc_str(s);
+            let r2 = bump2.emplace_str_with_capacity(s.len()).write_str(s);
+            assert_eq!(r1, r2);
+        }
+    }
+
+    fn alignment_single_values(values: Vec<u64>) -> () {
+        macro_rules! test_align {
+            ($align:literal) => {{
+                let bump = bumpalo::Bump::<$align>::with_min_align();
+                for v in &values {
+                    let r = bump.emplace().write(*v);
+                    let ptr = r as *const u64 as usize;
+                    assert_eq!(ptr % mem::align_of::<u64>(), 0);
+                    assert_eq!(ptr % $align, 0);
+                    assert_eq!(*r, *v);
+                }
+            }};
+        }
+        test_align!(1);
+        test_align!(2);
+        test_align!(4);
+        test_align!(8);
+        test_align!(16);
+    }
+
+    fn alignment_slices(data: Vec<Vec<u32>>) -> () {
+        macro_rules! test_align {
+            ($align:literal) => {{
+                let bump = bumpalo::Bump::<$align>::with_min_align();
+                for slice in &data {
+                    let r = bump.emplace_slice_with_capacity(slice.len()).copy_slice(slice);
+                    let ptr = r.as_ptr() as usize;
+                    assert_eq!(ptr % mem::align_of::<u32>(), 0);
+                    assert_eq!(ptr % $align, 0);
+                    assert_eq!(r, slice.as_slice());
+                }
+            }};
+        }
+        test_align!(1);
+        test_align!(2);
+        test_align!(4);
+        test_align!(8);
+        test_align!(16);
+    }
+
+    fn allocation_limits_respected(data: Vec<Vec<u8>>) -> () {
+        let bump = Bump::new();
+        bump.set_allocation_limit(Some(256));
+
+        for slice in &data {
+            let slice = &slice[..slice.len().min(64)];
+            match bump.try_emplace_slice_with_capacity::<u8>(slice.len()) {
+                Ok(place) => {
+                    match place.try_copy_slice(slice) {
+                        Ok(r) => assert_eq!(r, slice),
+                        Err(_) => {} // allocation limit hit during copy
+                    }
+                }
+                Err(_) => {} // allocation limit hit
+            }
+        }
+    }
+
+    fn extend_from_slice_copy(data1: Vec<u8>, data2: Vec<u8>) -> () {
+        let bump = Bump::new();
+        let mut place = bump.emplace_slice_with_capacity::<u8>(data1.len());
+        place.extend_from_slice_copy(&data1);
+        assert_eq!(place.as_slice(), data1.as_slice());
+
+        place.extend_from_slice_copy(&data2);
+        assert_eq!(place.len(), data1.len() + data2.len());
+        assert_eq!(&place.as_slice()[..data1.len()], data1.as_slice());
+        assert_eq!(&place.as_slice()[data1.len()..], data2.as_slice());
+        let _ = place.into_mut_slice();
+    }
+
+    fn extend_from_slice_clone(data1: Vec<u8>, data2: Vec<u8>) -> () {
+        let bump = Bump::new();
+        let mut place = bump.emplace_slice_with_capacity::<u8>(data1.len());
+        place.extend_from_slice_clone(&data1);
+        assert_eq!(place.as_slice(), data1.as_slice());
+
+        place.extend_from_slice_clone(&data2);
+        assert_eq!(place.len(), data1.len() + data2.len());
+        assert_eq!(&place.as_slice()[..data1.len()], data1.as_slice());
+        assert_eq!(&place.as_slice()[data1.len()..], data2.as_slice());
+        let _ = place.into_mut_slice();
+    }
+}

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -8,6 +8,7 @@ mod allocator_api;
 mod boxed;
 mod capacity;
 mod collect_in;
+mod emplace;
 mod quickcheck;
 mod quickchecks;
 mod string;


### PR DESCRIPTION
The goal is to both provide nicer fallible and delayed initialization and to refactor existing methods so that they are neatly implemented on top of these new APIs.