### PR TITLE
fix grow() fast path overflowing p by (old_size - delta) bytes by bum…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1937,11 +1937,10 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
             // Try to allocate the delta size within this same block so we can
             // reuse the currently allocated space.
             let delta = new_size - old_size;
-            if let Some(p) =
+            if let Some(_) =
                 self.try_alloc_layout_fast(layout_from_size_align(delta, old_layout.align())?)
             {
-                ptr::copy(ptr.as_ptr(), p.as_ptr(), old_size);
-                return Ok(p);
+                return Ok(ptr);
             }
         }
 


### PR DESCRIPTION
Bug in `grow`'s fast path

With `is_last_allocation(ptr) == true`, the pointer to the arena bump pointer coincides with `ptr + old_size`. It tries to do an in-place grow by allocating `delta = new_size - old_size` bytes right next to the current allocation and does:

```rust
ptr::copy(ptr.as_ptr(), p.as_ptr(), old_size);
```

`p` is a pointer to the region of `delta` bytes, not `new_size`. That means that `old_size` bytes will be copied from `ptr` to the `delta` sized region at `p` and it will return `p` as the new allocation, while `p` only has `delta` bytes available. The correct way would be to advance the bump pointer by `delta` (without copying anything since the data is already there) and to return `ptr` since no move happened.

Concretely, two bugs:
1. Calling `ptr::copy` in the situation when the data is in place.
2. Returning `p` while it has only `delta` bytes instead of `new_size`.

Fix should be something like:

```rust
if align_is_compatible && self.is_last_allocation(ptr) {
    // Try to allocate the delta size within this same block so we can
    // reuse the currently allocated space.
    let delta = new_size - old_size;

    if let Some(_) = self.try_alloc_layout_fast(layout_from_size_align(
        delta,
        old_layout.align(),
    )?) {
        return Ok(ptr);
    }
}
```
