### PR TITLE
Implement Allocator for Bump, not &Bump

### DIFF
--- a/src/emplace.rs
+++ b/src/emplace.rs
@@ -536,7 +536,7 @@ where
         let new_layout = Layout::array::<T>(new_capacity).map_err(|_| AllocErr)?;
 
         let ptr = self.inner.guard.ptr;
-        let new_ptr = unsafe { Bump::grow(self.bump(), ptr, old_layout, new_layout)? };
+        let new_ptr = unsafe { Bump::grow_internal(self.bump(), ptr, old_layout, new_layout)? };
 
         self.inner.guard.ptr = new_ptr;
         self.inner.ptr = new_ptr.cast();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1920,7 +1920,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     }
 
     #[inline]
-    unsafe fn grow(
+    unsafe fn grow_internal(
         &self,
         ptr: NonNull<u8>,
         old_layout: Layout,
@@ -2056,7 +2056,7 @@ unsafe impl<'a, const MIN_ALIGN: usize> alloc::Alloc for &'a Bump<MIN_ALIGN> {
         if new_size <= old_size {
             Bump::shrink(self, ptr, old_layout, new_layout)
         } else {
-            Bump::grow(self, ptr, old_layout, new_layout)
+            Bump::grow_internal(self, ptr, old_layout, new_layout)
         }
     }
 }
@@ -2073,7 +2073,7 @@ unsafe impl<'a, const MIN_ALIGN: usize> alloc::Alloc for &'a Bump<MIN_ALIGN> {
 fn _doctest_only() {}
 
 #[cfg(any(feature = "allocator_api", feature = "allocator-api2"))]
-unsafe impl<'a, const MIN_ALIGN: usize> Allocator for &'a Bump<MIN_ALIGN> {
+unsafe impl<const MIN_ALIGN: usize> Allocator for Bump<MIN_ALIGN> {
     #[inline]
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
         self.try_alloc_layout(layout)
@@ -2109,7 +2109,7 @@ unsafe impl<'a, const MIN_ALIGN: usize> Allocator for &'a Bump<MIN_ALIGN> {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        Bump::<MIN_ALIGN>::grow(self, ptr, old_layout, new_layout)
+        Bump::<MIN_ALIGN>::grow_internal(self, ptr, old_layout, new_layout)
             .map(|p| unsafe {
                 NonNull::new_unchecked(ptr::slice_from_raw_parts_mut(p.as_ptr(), new_layout.size()))
             })


### PR DESCRIPTION
Hey, I'm helping with the current work on the `allocator_api` feature and your crate is the most commonly used example of an `Allocator` implementor outside `std`, so thank you for writing it!

Generally the allocator api is written to work with owning allocators as well as static allocators (like `System`).
This means that you can freely implement `Allocator` for `Bump`, instead of for `&Bump`.
Doing so is sound because allocator implementors are explicitly allowed to clear their allocations like you do.

This will also allow your allocator to be used inside `Box` and `Arc`, i.e. `Arc<Bump>` can be used as the allocator for long-lived allocations.

The existing implementation for `&Bump` follows from the blanket impl in `std` and `allocator-api2`.

Fixes #283