### PR TITLE
Fix out-of-bounds write in `EmplaceSlice::try_{copy,clone}_slice`

### DIFF
--- a/src/emplace.rs
+++ b/src/emplace.rs
@@ -536,7 +536,7 @@ where
         let new_layout = Layout::array::<T>(new_capacity).map_err(|_| AllocErr)?;
 
         let ptr = self.inner.guard.ptr;
-        let new_ptr = unsafe { Bump::grow_internal(self.bump(), ptr, old_layout, new_layout)? };
+        let new_ptr = unsafe { self.bump().grow_internal(ptr, old_layout, new_layout)? };
 
         self.inner.guard.ptr = new_ptr;
         self.inner.ptr = new_ptr.cast();
@@ -950,7 +950,7 @@ where
     where
         T: Copy,
     {
-        self.try_reserve_exact(from.len().saturating_sub(self.capacity))?;
+        self.try_grow(from.len())?;
         unsafe {
             ptr::copy_nonoverlapping(from.as_ptr(), self.base_ptr(), from.len());
         }
@@ -1004,7 +1004,7 @@ where
     where
         T: Clone,
     {
-        self.try_reserve_exact(from.len().saturating_sub(self.capacity))?;
+        self.try_grow(from.len())?;
         for (i, val) in from.iter().cloned().enumerate() {
             unsafe {
                 ptr::write(self.base_ptr().add(i), val);

--- a/tests/all/emplace.rs
+++ b/tests/all/emplace.rs
@@ -104,10 +104,15 @@ fn emplace_slice_operation_sequences() -> CheckResult<EmplaceSliceProgram> {
 #[test]
 fn emplace_slice_copy() -> CheckResult<Vec<u8>> {
     check().run(|data: &Vec<u8>| -> Result<(), String> {
-        let bump = Bump::new();
-        let place = bump.emplace_slice_with_capacity(data.len());
-        let result = place.copy_slice(&data);
-        assert_eq!(result, data.as_slice());
+        // Sweep the initial capacity across values below, equal to, and above
+        // the data length. This exercises all cases of our capacity-growing
+        // behavior.
+        for capacity in 0..=(data.len() + 2).min(10) {
+            let bump = Bump::new();
+            let place = bump.emplace_slice_with_capacity(capacity);
+            let result = place.copy_slice(data.as_slice());
+            assert_eq!(result, data.as_slice());
+        }
         Ok(())
     })
 }
@@ -115,10 +120,13 @@ fn emplace_slice_copy() -> CheckResult<Vec<u8>> {
 #[test]
 fn emplace_slice_clone() -> CheckResult<Vec<u8>> {
     check().run(|data: &Vec<u8>| -> Result<(), String> {
-        let bump = Bump::new();
-        let place = bump.emplace_slice_with_capacity(data.len());
-        let result = place.clone_slice(&data);
-        assert_eq!(result, data.as_slice());
+        // See comment in `emplace_slice_copy`.
+        for capacity in 0..=(data.len() + 2).min(10) {
+            let bump = Bump::new();
+            let place = bump.emplace_slice_with_capacity(capacity);
+            let result = place.clone_slice(data.as_slice());
+            assert_eq!(result, data.as_slice());
+        }
         Ok(())
     })
 }
@@ -431,4 +439,38 @@ fn extend_from_slice_clone() -> CheckResult<(Vec<u8>, Vec<u8>)> {
         let _ = place.into_mut_slice();
         Ok(())
     })
+}
+
+#[test]
+fn issue_330_emplace_slice_copy_grows() {
+    for &(capacity, len) in &[(1, 2), (1, 10), (4, 6), (4, 8), (4, 100), (16, 17)] {
+        let bump = Bump::new();
+        let data: Vec<u8> = (0..len).map(|i| i as u8).collect();
+        let place = bump.emplace_slice_with_capacity::<u8>(capacity);
+        let result = place.copy_slice(&data);
+        assert_eq!(result, data.as_slice());
+    }
+
+    // The default capacity (from `emplace_slice`) is smaller than the data.
+    let bump = Bump::new();
+    let data: Vec<u8> = (0..64).collect();
+    let result = bump.emplace_slice::<u8>().copy_slice(&data);
+    assert_eq!(result, data.as_slice());
+}
+
+#[test]
+fn issue_330_emplace_slice_clone_grows() {
+    for &(capacity, len) in &[(1, 2), (1, 10), (4, 6), (4, 8), (4, 100), (16, 17)] {
+        let bump = Bump::new();
+        let data: Vec<String> = (0..len).map(|i| i.to_string()).collect();
+        let place = bump.emplace_slice_with_capacity::<String>(capacity);
+        let result = place.clone_slice(&data);
+        assert_eq!(result, data.as_slice());
+    }
+
+    // The default capacity (from `emplace_slice`) is smaller than the data.
+    let bump = Bump::new();
+    let data: Vec<String> = (0..64).map(|i| i.to_string()).collect();
+    let result = bump.emplace_slice::<String>().clone_slice(&data);
+    assert_eq!(result, data.as_slice());
 }


### PR DESCRIPTION
`try_copy_slice` and `try_clone_slice` computed the amount to reserve as `from.len().saturating_sub(self.capacity)` and passed it to `try_reserve_exact`, which adds the argument to `self.len` rather than to `self.capacity`. When `from.len()` exceeded the capacity, the allocation was not grown enough, so writing `from.len()` elements ran past the end of the allocation.

Grow to a total capacity of `from.len()` instead.

The `emplace_slice_copy` and `emplace_slice_clone` property tests missed this because they always sized the initial capacity to `data.len()`, so the growth path never ran. They now sweep the initial capacity so that growth is exercised.

Fixes #330